### PR TITLE
Replace delete with replace on ghr

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -120,7 +120,7 @@ jobs:
           command: |
             echo "TAG: ${CIRCLE_TAG}"
             VERSION=${CIRCLE_TAG}
-            ghr -t ${GITHUB_TOKEN} -u ${CIRCLE_PROJECT_USERNAME} -r ${CIRCLE_PROJECT_REPONAME} -c ${CIRCLE_SHA1} -delete ${VERSION} ./dist/
+            ghr -t ${GITHUB_TOKEN} -u ${CIRCLE_PROJECT_USERNAME} -r ${CIRCLE_PROJECT_REPONAME} -c ${CIRCLE_SHA1} -replace ${VERSION} ./dist/
 
   deploy-pypi:
     executor:


### PR DESCRIPTION
Delete completely removes the release and any information.

This is especially inconvenient if you have the release prepared from before hand since it will complete remove any information contained.