### PR TITLE
Use AfterViewInit hook to calculate contact and channel items per row

### DIFF
--- a/src/app/components/channel-list/channel-list.component.ts
+++ b/src/app/components/channel-list/channel-list.component.ts
@@ -4,8 +4,7 @@ import {
     OnDestroy,
     ViewChild,
     ElementRef,
-    HostListener,
-    AfterContentInit,
+    AfterViewInit,
 } from '@angular/core';
 import { Channel } from '../../models/channel';
 import { EMPTY, Subject, Observable, fromEvent } from 'rxjs';
@@ -42,8 +41,7 @@ import { TokenUtils } from '../../utils/token.utils';
     styleUrls: ['./channel-list.component.css'],
     animations: Animations.stretchInOut,
 })
-export class ChannelListComponent
-    implements OnInit, OnDestroy, AfterContentInit {
+export class ChannelListComponent implements OnInit, OnDestroy, AfterViewInit {
     private static MIN_CHANNEL_WIDTH = 183;
 
     @ViewChild('channel_list', { static: true })
@@ -111,8 +109,8 @@ export class ChannelListComponent
             });
     }
 
-    ngAfterContentInit() {
-        this.calculateItemsPerRow();
+    ngAfterViewInit() {
+        setTimeout(() => this.calculateItemsPerRow());
     }
 
     ngOnDestroy() {

--- a/src/app/components/contact-list/contact-list.component.ts
+++ b/src/app/components/contact-list/contact-list.component.ts
@@ -5,7 +5,7 @@ import {
     ViewChild,
     ElementRef,
     Input,
-    AfterContentInit,
+    AfterViewInit,
 } from '@angular/core';
 import { Contact } from '../../models/contact';
 import { AddressBookService } from '../../services/address-book.service';
@@ -30,8 +30,7 @@ import { takeUntil, debounceTime } from 'rxjs/operators';
     styleUrls: ['./contact-list.component.css'],
     animations: Animations.stretchInOut,
 })
-export class ContactListComponent
-    implements OnInit, OnDestroy, AfterContentInit {
+export class ContactListComponent implements OnInit, OnDestroy, AfterViewInit {
     private static MIN_CONTACT_WIDTH = 280;
 
     @Input() showAll = false;
@@ -85,8 +84,8 @@ export class ContactListComponent
             });
     }
 
-    ngAfterContentInit() {
-        this.calculateItemsPerRow();
+    ngAfterViewInit() {
+        setTimeout(() => this.calculateItemsPerRow());
     }
 
     ngOnDestroy() {


### PR DESCRIPTION
The width of the containers is safely only available in the AfterViewInit hook. But in our case this leads to the `ExpressionChangedAfterItHasBeenCheckedError`, because we alter values after change detection. I tried to fix it in many ways already, but the only fix I came up with is the `setTimeout`.