### PR TITLE
Show top tokens and contacts based on sent transfers

### DIFF
--- a/src/app/app.component.spec.ts
+++ b/src/app/app.component.spec.ts
@@ -80,7 +80,7 @@ describe('AppComponent', () => {
 
         const paymentHistoryPollingMock = stub<PaymentHistoryPollingService>();
         // @ts-ignore
-        paymentHistoryPollingMock.paymentHistory$ = of([]);
+        paymentHistoryPollingMock.newPaymentEvents$ = of([]);
 
         const channelPollingMock = stub<ChannelPollingService>();
         // @ts-ignore

--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -129,7 +129,7 @@ export class AppComponent implements OnInit, OnDestroy {
             .pipe(takeUntil(this.ngUnsubscribe))
             .subscribe();
 
-        this.paymentHistoryPollingService.paymentHistory$
+        this.paymentHistoryPollingService.newPaymentEvents$
             .pipe(takeUntil(this.ngUnsubscribe))
             .subscribe();
 

--- a/src/app/components/history-table/history-table.component.html
+++ b/src/app/components/history-table/history-table.component.html
@@ -119,7 +119,10 @@
                 fxLayoutAlign="start end"
                 fxFlex.xs="1 0 0"
             >
-                <div *ngIf="event.userToken" class="table__amount">
+                <div
+                    *ngIf="getUserToken(event) as userToken"
+                    class="table__amount"
+                >
                     <ng-container *ngIf="isReceivedEvent(event); else minus">
                         +
                     </ng-container>
@@ -128,21 +131,20 @@
                     </ng-template>
                     <span
                         *ngIf="
-                            event.amount
-                                | decimal: event.userToken.decimals as amount
+                            event.amount | decimal: userToken.decimals as amount
                         "
                         [matTooltip]="amount"
                     >
                         {{ amount | displayDecimals: 3 }}
                     </span>
                     <span
-                        matTooltip="{{ event.userToken.name }}
-                            {{ event.userToken.address }}
+                        matTooltip="{{ userToken.name }}
+                            {{ userToken.address }}
                             (Click to copy)"
                         ngxClipboard
-                        [cbContent]="event.userToken.address"
+                        [cbContent]="userToken.address"
                     >
-                        {{ event.userToken.symbol }}
+                        {{ userToken.symbol }}
                     </span>
                 </div>
                 <div>

--- a/src/app/interceptors/error-handling.interceptor.spec.ts
+++ b/src/app/interceptors/error-handling.interceptor.spec.ts
@@ -224,7 +224,7 @@ describe('ErrorHandlingInterceptor', () => {
         const attemptSpy = spyOn(raidenService, 'attemptRpcConnection');
         const refreshSpy = spyOn(
             raidenService,
-            'refreshAddress'
+            'reconnectSuccessful'
         ).and.callFake(() => {});
 
         service.getData().subscribe(

--- a/src/app/interceptors/error-handling.interceptor.ts
+++ b/src/app/interceptors/error-handling.interceptor.ts
@@ -32,7 +32,7 @@ export class ErrorHandlingInterceptor implements HttpInterceptor {
                     this.notificationService.apiError
                 ) {
                     this.raidenService.attemptRpcConnection();
-                    this.raidenService.refreshAddress();
+                    this.raidenService.reconnectSuccessful();
                     this.notificationService.apiError = undefined;
                 }
             }),

--- a/src/app/models/payment-event.ts
+++ b/src/app/models/payment-event.ts
@@ -1,5 +1,4 @@
 import BigNumber from 'bignumber.js';
-import { UserToken } from './usertoken';
 
 export interface PaymentEvent {
     readonly reason?: string;
@@ -13,5 +12,4 @@ export interface PaymentEvent {
     readonly identifier?: BigNumber;
     readonly log_time: string;
     readonly token_address: string;
-    userToken?: UserToken;
 }

--- a/src/app/services/payment-history-polling.service.spec.ts
+++ b/src/app/services/payment-history-polling.service.spec.ts
@@ -48,11 +48,11 @@ describe('PaymentHistoryPollingService', () => {
         }
     ));
 
-    it('should refresh the payment history every polling interval', inject(
+    it('should refresh the new payment events every polling interval', inject(
         [PaymentHistoryPollingService],
         fakeAsync((service: PaymentHistoryPollingService) => {
             getPaymentHistorySpy.and.returnValue(of([paymentEvent]));
-            service.paymentHistory$.subscribe((value) =>
+            service.newPaymentEvents$.subscribe((value) =>
                 expect(value).toEqual([paymentEvent])
             );
             const refreshSpy = spyOn(service, 'refresh');
@@ -72,13 +72,30 @@ describe('PaymentHistoryPollingService', () => {
                 };
             };
             getPaymentHistorySpy.and.returnValues(
-                from([[paymentEvent], [paymentEvent, paymentEvent2]])
+                from([[], [paymentEvent], [paymentEvent2]])
             );
-            service.paymentHistory$.subscribe();
+            service.newPaymentEvents$.subscribe();
 
             expect(
                 notificationService.addInfoNotification
-            ).toHaveBeenCalledTimes(1);
+            ).toHaveBeenCalledTimes(2);
+        }
+    ));
+
+    it('should be able to poll the history for a token and a partner', inject(
+        [PaymentHistoryPollingService],
+        (service: PaymentHistoryPollingService) => {
+            getPaymentHistorySpy.and.returnValue(of([paymentEvent]));
+            service
+                .getHistory(paymentEvent.token_address, paymentEvent.initiator)
+                .subscribe((value) => expect(value).toEqual([paymentEvent]));
+            expect(getPaymentHistorySpy).toHaveBeenCalledTimes(1);
+            expect(getPaymentHistorySpy).toHaveBeenCalledWith(
+                paymentEvent.token_address,
+                paymentEvent.initiator,
+                undefined,
+                undefined
+            );
         }
     ));
 });

--- a/src/app/services/raiden.service.spec.ts
+++ b/src/app/services/raiden.service.spec.ts
@@ -1270,7 +1270,7 @@ describe('RaidenService', () => {
             }
         );
 
-        service.refreshAddress();
+        service.reconnectSuccessful();
 
         request = mockHttp.expectOne({
             url: `${endpoint}/address`,
@@ -1347,14 +1347,11 @@ describe('RaidenService', () => {
         flush();
     }));
 
-    it('should query the payment history with UserTokens added', () => {
+    it('should query the payment history', () => {
         const partnerAddress = '0xc52952ebad56f2c5e5b42bb881481ae27d036475';
-        const eventWithToken = Object.assign({}, paymentEvent, {
-            userToken: token,
-        });
         service.getPaymentHistory(tokenAddress, partnerAddress).subscribe(
             (history: PaymentEvent[]) => {
-                expect(history).toEqual([eventWithToken]);
+                expect(history).toEqual([paymentEvent]);
             },
             (error) => {
                 fail(error);
@@ -1369,6 +1366,19 @@ describe('RaidenService', () => {
         getPendingTransfersRequest.flush(losslessStringify([paymentEvent]), {
             status: 200,
             statusText: '',
+        });
+    });
+
+    it('should query the payment history and use limit and offset parameters', () => {
+        const limit = 5;
+        const offset = 10;
+        service
+            .getPaymentHistory(undefined, undefined, limit, offset)
+            .subscribe();
+
+        mockHttp.expectOne({
+            url: `${endpoint}/payments?limit=${limit}&offset=${offset}`,
+            method: 'GET',
         });
     });
 

--- a/src/app/utils/token.utils.spec.ts
+++ b/src/app/utils/token.utils.spec.ts
@@ -49,25 +49,31 @@ describe('TokenUtils', () => {
 
     it('should give connected token a lower index', () => {
         expect(
-            TokenUtils.compareTokens(connectedToken, unconnectedToken)
+            TokenUtils.compareTokens(connectedToken, unconnectedToken, 0, 0)
         ).toEqual(-1);
     });
 
     it('should give unconnected token a higher index', () => {
         expect(
-            TokenUtils.compareTokens(unconnectedToken, connectedToken)
+            TokenUtils.compareTokens(unconnectedToken, connectedToken, 0, 0)
         ).toEqual(1);
     });
 
     it('should compare not connected tokens depending on balance', () => {
         expect(
-            TokenUtils.compareTokens(unconnectedToken, unconnectedToken2)
+            TokenUtils.compareTokens(unconnectedToken, unconnectedToken2, 0, 0)
         ).toEqual(50);
     });
 
     it('should compare connected tokens depending on sum channel balances', () => {
         expect(
-            TokenUtils.compareTokens(connectedToken, connectedToken2)
+            TokenUtils.compareTokens(connectedToken, connectedToken2, 0, 0)
         ).toEqual(-70);
+    });
+
+    it('should compare tokens based on usage', () => {
+        expect(
+            TokenUtils.compareTokens(connectedToken, connectedToken2, 4, 1)
+        ).toEqual(-3);
     });
 });

--- a/src/app/utils/token.utils.ts
+++ b/src/app/utils/token.utils.ts
@@ -2,10 +2,17 @@ import { UserToken } from '../models/usertoken';
 import { amountToDecimal } from './amount.converter';
 
 export class TokenUtils {
-    static compareTokens(a: UserToken, b: UserToken): number {
+    static compareTokens(
+        a: UserToken,
+        b: UserToken,
+        aUsage: number,
+        bUsage: number
+    ): number {
         const aConnected = a.connected && a.sumChannelBalances;
         const bConnected = b.connected && b.sumChannelBalances;
-        if (aConnected && bConnected) {
+        if (aUsage !== bUsage) {
+            return bUsage - aUsage;
+        } else if (aConnected && bConnected) {
             return amountToDecimal(b.sumChannelBalances, b.decimals)
                 .minus(amountToDecimal(a.sumChannelBalances, a.decimals))
                 .toNumber();

--- a/src/testing/test-data.ts
+++ b/src/testing/test-data.ts
@@ -113,7 +113,7 @@ export function createPaymentEvent(
     const event: PaymentEvent = {
         event: eventType,
         log_time: new Date().toISOString().slice(0, -1),
-        token_address: obj.userToken ? obj.userToken.address : createAddress(),
+        token_address: createAddress(),
     };
     if (eventType === 'EventPaymentSentSuccess') {
         Object.assign(event, {


### PR DESCRIPTION
closes #436 
The history table still queries the complete history. It is not so easy to query only the relevant payment events and at the same time keep the search filter functionality. But I am working on it.