### PR TITLE
Fix notification panel button on Brave browser

### DIFF
--- a/src/app/app.component.spec.ts
+++ b/src/app/app.component.spec.ts
@@ -179,7 +179,7 @@ describe('AppComponent', () => {
             notificationSidenav,
             'toggle'
         ).and.callThrough();
-        clickElement(fixture.debugElement, '#notification-button');
+        clickElement(fixture.debugElement, '.notification-panel-button');
         expect(toggleSpy).toHaveBeenCalledTimes(1);
     });
 

--- a/src/app/components/header/header.component.css
+++ b/src/app/components/header/header.component.css
@@ -55,12 +55,12 @@
     line-height: 15px !important;
 }
 
-.notification-button {
+.notification-panel-button {
     height: 50px !important;
     width: 50px !important;
     background-color: rgba(255, 255, 255, 0.06);
 }
 
-.notification-button__icon {
+.notification-panel-button__icon {
     color: #888888;
 }

--- a/src/app/components/header/header.component.html
+++ b/src/app/components/header/header.component.html
@@ -107,24 +107,26 @@
         fxLayoutGap="22px"
         fxFlex.gt-md="334 0 0"
     >
-        <app-search-field fxFlex fxFlex.lt-lg="0 1 233px"></app-search-field>
+        <app-search-field
+            fxFlex="1 0 0"
+            fxFlex.lt-lg="0 1 233px"
+        ></app-search-field>
         <button
-            class="notification-button"
+            class="notification-panel-button"
             mat-icon-button
             matTooltip="Open notification panel"
             (click)="toggleNotifications.emit(true)"
-            id="notification-button"
         >
             <mat-icon
                 *ngIf="(numberOfNotifications$ | async) === 0; else show_badge"
-                class="notification-button__icon"
+                class="notification-panel-button__icon"
                 svgIcon="notification"
                 aria-label="Open notification panel"
             >
             </mat-icon>
             <ng-template #show_badge>
                 <mat-icon
-                    class="notification-button__icon"
+                    class="notification-panel-button__icon"
                     svgIcon="notification-with-badge"
                     aria-label="Open notification panel"
                     id="badge"


### PR DESCRIPTION
The Brave bowser somehow adds a `display: none !important;` to the `notification-button` class.