### PR TITLE
Bump version: 0.20.0-alpha6 → 1.0.0

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 0.20.0-alpha6
+current_version = 1.0.0
 commit = True
 tag = False
 parse = (?P<major>\d+)\.(?P<minor>\d+)\.(?P<patch>\d+)(\-(?P<release>[a-z]+)(?P<build>\d+))?

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 # Changelog
 
 ## [Unreleased]
+
+## [1.0.0] - 2020-06-12
 ### Changed
 - **Complete redesign of the UI**
 - [#189] Only shows one notification for a channel deposit.
@@ -140,7 +142,8 @@ token network.
 ### Changed
 - First python package release.
 
-[Unreleased]: https://github.com/raiden-network/webui/compare/v0.11.0...HEAD
+[Unreleased]: https://github.com/raiden-network/webui/compare/v1.0.0...HEAD
+[1.0.0]: https://github.com/raiden-network/webui/compare/v0.11.0...v1.0.0
 [0.11.0]: https://github.com/raiden-network/webui/compare/v0.10.4...v0.11.0
 [0.10.4]: https://github.com/raiden-network/webui/compare/v0.10.3...v0.10.4
 [0.10.3]: https://github.com/raiden-network/webui/compare/v0.10.2...v0.10.3

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "raiden-webui",
-  "version": "0.20.0-alpha6",
+  "version": "1.0.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "raiden-webui",
-  "version": "0.20.0-alpha6",
+  "version": "1.0.0",
   "license": "MIT",
   "scripts": {
     "ng": "ng",

--- a/setup.py
+++ b/setup.py
@@ -85,7 +85,7 @@ with open('README.md', encoding='utf-8') as readme_file:
 
 history = ''
 
-version = '0.20.0-alpha6'  # Do not edit: this is maintained by bumpversion (see .bumpversion.cfg)
+version = '1.0.0'  # Do not edit: this is maintained by bumpversion (see .bumpversion.cfg)
 
 setup(
     name='raiden-webui',

--- a/src/version.ts
+++ b/src/version.ts
@@ -1,2 +1,2 @@
 // Do not change this, this is maintained by bumpversion.
-export const version = '0.20.0-alpha6';
+export const version = '1.0.0';


### PR DESCRIPTION
Testing went well and this version can be released now.