### PR TITLE
Introduces renovate for dependency updates

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -1,0 +1,13 @@
+{
+  "extends": [
+    "config:base"
+  ],
+  "commitMessagePrefix": "dependencies:",
+  "labels": ["dependencies"],
+  "lockFileMaintenance": { "enabled": true },
+  "schedule": ["after 8am on thursday"],
+  "prConcurrentLimit": 15,
+  "prHourlyLimit": 5,
+  "rangeStrategy": "pin",
+  "timezone": "Europe/Berlin"
+}


### PR DESCRIPTION
Replacing dependabot with renovate. 

It has better handling for monorepo dependencies, hopefully it will handle all the angular mono repo dependency updates in a single PR