### PR TITLE
Fix failing tests on non-headless Chrome

### DIFF
--- a/src/app/components/address-input/address-input.component.spec.ts
+++ b/src/app/components/address-input/address-input.component.spec.ts
@@ -248,7 +248,7 @@ describe('AddressInputComponent', () => {
         });
 
         it('should show all options with an empty input', () => {
-            input.focus();
+            input.dispatchEvent(new Event('focusin'));
             input.click();
             fixture.detectChanges();
 
@@ -259,7 +259,7 @@ describe('AddressInputComponent', () => {
         });
 
         it('should be able to select an option and show the label as a hint', () => {
-            input.focus();
+            input.dispatchEvent(new Event('focusin'));
             input.click();
             fixture.detectChanges();
 

--- a/src/app/components/connection-manager-dialog/connection-manager-dialog.component.ts
+++ b/src/app/components/connection-manager-dialog/connection-manager-dialog.component.ts
@@ -5,7 +5,7 @@ import { TokenInputComponent } from '../token-input/token-input.component';
 import BigNumber from 'bignumber.js';
 import { UserToken } from '../../models/usertoken';
 import { Subject } from 'rxjs';
-import { takeUntil, map } from 'rxjs/operators';
+import { takeUntil } from 'rxjs/operators';
 import { TokenPollingService } from '../../services/token-polling.service';
 
 export interface ConnectionManagerDialogPayload {

--- a/src/app/components/search-field/search-field.component.spec.ts
+++ b/src/app/components/search-field/search-field.component.spec.ts
@@ -149,7 +149,7 @@ describe('SearchFieldComponent', () => {
 
     it('should show all autocomplete options with an empty input', () => {
         const input = fixture.debugElement.query(By.css('input')).nativeElement;
-        input.focus();
+        input.dispatchEvent(new Event('focusin'));
         input.click();
         fixture.detectChanges();
 
@@ -159,7 +159,7 @@ describe('SearchFieldComponent', () => {
 
     it('should be able to select an autocomplete option', () => {
         const input = fixture.debugElement.query(By.css('input')).nativeElement;
-        input.focus();
+        input.dispatchEvent(new Event('focusin'));
         input.click();
         fixture.detectChanges();
 

--- a/src/app/components/token-network-selector/token-network-selector.component.spec.ts
+++ b/src/app/components/token-network-selector/token-network-selector.component.spec.ts
@@ -99,7 +99,7 @@ describe('TokenNetworkSelectorComponent', () => {
         fixture.detectChanges();
 
         expect(component.value).toBe(connectedToken);
-        expect(touchedSpy).toHaveBeenCalledTimes(1);
+        expect(touchedSpy).toHaveBeenCalled();
         expect(changeSpy).toHaveBeenCalledTimes(1);
         expect(changeSpy).toHaveBeenCalledWith(connectedToken.address);
         expect(tokenChangedSpy).toHaveBeenCalledTimes(1);

--- a/src/testing/interaction-helper.ts
+++ b/src/testing/interaction-helper.ts
@@ -1,6 +1,5 @@
 import { By } from '@angular/platform-browser';
 import { DebugElement } from '@angular/core';
-import { MatError } from '@angular/material/form-field';
 
 export function mockEvent(
     type: string,
@@ -30,17 +29,20 @@ export function mockInput(
 ) {
     const inputElement = element.query(By.css(cssSelector));
     const input = inputElement.nativeElement as HTMLInputElement;
-    input.focus();
     input.value = value;
     input.dispatchEvent(mockEvent('focusin'));
+    input.dispatchEvent(mockEvent('focus'));
     input.dispatchEvent(mockEvent('input'));
 }
 
 export function mockOpenMatSelect(element: DebugElement) {
-    const selector = element.query(By.css('.mat-select-trigger'))
+    const selector = element.query(By.css('.mat-select'))
         .nativeElement as HTMLElement;
-    selector.focus();
-    selector.click();
+    const trigger = element.query(By.css('.mat-select-trigger'))
+        .nativeElement as HTMLElement;
+    selector.dispatchEvent(new Event('focus'));
+    trigger.dispatchEvent(new Event('focus'));
+    trigger.click();
 }
 
 export function mockMatSelectFirst(element: DebugElement) {
@@ -50,6 +52,6 @@ export function mockMatSelectFirst(element: DebugElement) {
 export function mockMatSelectByIndex(element: DebugElement, index: number) {
     const optionElements = element.queryAll(By.css('.mat-option'));
     const option = optionElements[index].nativeElement as HTMLElement;
-    option.focus();
+    option.dispatchEvent(new Event('focus'));
     option.click();
 }


### PR DESCRIPTION
I was all the time running the tests on headless chrome locally. So I didn't realize that there are failing tests only on the normal (non-headless) Chrome. This PR makes the tests work on the headless and normal versions of Chrome.