### PR TITLE
Bump version: 1.0.2 → 1.1.0

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 1.0.2
+current_version = 1.1.0
 commit = True
 tag = False
 parse = (?P<major>\d+)\.(?P<minor>\d+)\.(?P<patch>\d+)(\-(?P<release>[a-z]+)(?P<build>\d+))?

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 # Changelog
 
 ## [Unreleased]
+
+## [1.1.0] - 2020-12-02
 ### Changed
 - [#547] Connection manager is replaced by a new quick connect dialog which transparently opens channels with suggestions by a pathfinding service.
 
@@ -160,7 +162,8 @@ token network.
 ### Changed
 - First python package release.
 
-[Unreleased]: https://github.com/raiden-network/webui/compare/v1.0.2...HEAD
+[Unreleased]: https://github.com/raiden-network/webui/compare/v1.1.0...HEAD
+[1.1.0]: https://github.com/raiden-network/webui/compare/v1.0.2...v1.1.0
 [1.0.2]: https://github.com/raiden-network/webui/compare/v1.0.1...v1.0.2
 [1.0.1]: https://github.com/raiden-network/webui/compare/v1.0.0...v1.0.1
 [1.0.0]: https://github.com/raiden-network/webui/compare/v0.11.0...v1.0.0

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "raiden-webui",
-  "version": "1.0.2",
+  "version": "1.1.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "raiden-webui",
-  "version": "1.0.2",
+  "version": "1.1.0",
   "license": "MIT",
   "scripts": {
     "ng": "ng",

--- a/setup.py
+++ b/setup.py
@@ -85,7 +85,7 @@ with open('README.md', encoding='utf-8') as readme_file:
 
 history = ''
 
-version = '1.0.2'  # Do not edit: this is maintained by bumpversion (see .bumpversion.cfg)
+version = '1.1.0'  # Do not edit: this is maintained by bumpversion (see .bumpversion.cfg)
 
 setup(
     name='raiden-webui',

--- a/src/version.ts
+++ b/src/version.ts
@@ -1,2 +1,2 @@
 // Do not change this, this is maintained by bumpversion.
-export const version = '1.0.2';
+export const version = '1.1.0';


### PR DESCRIPTION
New release with the connection manager replacement and the payment identifier.