### PR TITLE
Fix TokenNetworkSelectorComponent to get initialized with a token 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 # Changelog
 
 ## [Unreleased]
+### Fixed
+- [#590] Fixed a bug that prevented to select the all networks view.
 
 ## [1.1.1] - 2020-12-03
 ### Fixed
@@ -187,6 +189,7 @@ token network.
 [0.7.0]: https://github.com/raiden-network/webui/compare/v0.6.0...v0.7.0
 [0.6.0]: https://github.com/raiden-network/webui/releases/tag/v0.6.0
 
+[#590]: https://github.com/raiden-network/webui/issues/590
 [#580]: https://github.com/raiden-network/webui/issues/580
 [#547]: https://github.com/raiden-network/webui/issues/547
 [#485]: https://github.com/raiden-network/webui/issues/485

--- a/src/app/components/token-network-selector/token-network-selector.component.ts
+++ b/src/app/components/token-network-selector/token-network-selector.component.ts
@@ -30,8 +30,8 @@ export class TokenNetworkSelectorComponent implements ControlValueAccessor {
     @Input() placeholder = 'Token Network';
     @Input() selectorClass = '';
     @Input() panelClass = '';
+    @Input() value: UserToken;
 
-    value: UserToken;
     tokens$: Observable<UserToken[]>;
 
     constructor(

--- a/src/app/components/token/token.component.html
+++ b/src/app/components/token/token.component.html
@@ -78,6 +78,7 @@
 >
     <div class="card__top" fxLayout="row" fxLayoutAlign="center">
         <app-token-network-selector
+            [value]="selectedToken"
             [showChannelBalance]="true"
             [setSelectedToken]="true"
             [showRegisterButton]="!production"

--- a/src/app/components/token/token.component.spec.ts
+++ b/src/app/components/token/token.component.spec.ts
@@ -221,6 +221,17 @@ describe('TokenComponent', () => {
                 },
             ]);
         });
+
+        it('should be able to initialize the token selector with a token', () => {
+            const selectedTokenService = TestBed.inject(SelectedTokenService);
+            selectedTokenService.setToken(tokens[0]);
+            fixture.detectChanges();
+
+            const tokenSelector: TokenNetworkSelectorComponent = fixture.debugElement.query(
+                By.directive(TokenNetworkSelectorComponent)
+            ).componentInstance;
+            expect(tokenSelector.value).toEqual(tokens[0]);
+        });
     });
 
     describe('as token view', () => {


### PR DESCRIPTION
Fixes #590 

This fixes a bug that made it not possible to select the all networks view after switching to a different navigation entry.
It was caused because the token network selector was not initialized with the currently selected token.