### PR TITLE
Configure Renovate to use master issue approvals for minor typescript updates

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -15,6 +15,11 @@
     {
       "updateTypes": ["major"],
       "masterIssueApproval": true
+    },
+    {
+      "matchPackageNames": ["typescript"],
+      "updateTypes": ["minor"],
+      "masterIssueApproval": true
     }
   ],
   "masterIssue": true,


### PR DESCRIPTION
It's the second time we have a failing CI for dependency updates because of the typescript version not matching the required one by Angular. Minor typescript updates should only be applied when Angular supports them. So I added a rule for Renovate to make master issue approvals necessary for minor typescript updates.