### PR TITLE
Exclude typescript from minor dependency updates

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -8,9 +8,18 @@
       "packagePatterns": [
         "*"
       ],
-      "updateTypes": ["minor", "patch", "pin", "digest", "lockFileMaintenance", "rollback", "bump"],
-      "groupName": "all non-major dependencies",
-      "groupSlug": "all-minor-patch"
+      "updateTypes": ["patch", "pin", "digest", "lockFileMaintenance", "rollback", "bump"],
+      "groupName": "all non-major and non-minor dependencies",
+      "groupSlug": "all-patch"
+    },
+    {
+      "packagePatterns": [
+        "*"
+      ],
+      "excludePackageNames": ["typescript"],
+      "updateTypes": ["minor"],
+      "groupName": "all minor dependencies",
+      "groupSlug": "all-minor"
     },
     {
       "updateTypes": ["major"],


### PR DESCRIPTION
In #597 I added an update group for typescript to make master issue approvals necessary for minor updates. Unfortunately, typescript is still matched by the non-major update group and Renovate still adds the minor update for typescript in its PRs. This makes it necessary to split the non-major update group into minor and patch groups in order to exclude typescript from the former.