### PR TITLE
UDC API integration

### DIFF
--- a/src/app/interceptors/error-handling.interceptor.spec.ts
+++ b/src/app/interceptors/error-handling.interceptor.spec.ts
@@ -29,11 +29,6 @@ describe('ErrorHandlingInterceptor', () => {
     let raidenConfig: RaidenConfig;
 
     beforeEach(() => {
-        notificationService = jasmine.createSpyObj('NotificationService', [
-            'addErrorNotification',
-        ]);
-        notificationService.apiError = undefined;
-
         TestBed.configureTestingModule({
             imports: [HttpClientTestingModule],
             providers: [
@@ -45,10 +40,7 @@ describe('ErrorHandlingInterceptor', () => {
                     multi: true,
                 },
                 TestProviders.MockRaidenConfigProvider(),
-                {
-                    provide: NotificationService,
-                    useValue: notificationService,
-                },
+                TestProviders.SpyNotificationServiceProvider(),
                 TestProviders.AddressBookStubProvider(),
             ],
         });

--- a/src/app/modules/raiden-icons/raiden-icons.module.ts
+++ b/src/app/modules/raiden-icons/raiden-icons.module.ts
@@ -40,6 +40,8 @@ export class RaidenIconsModule {
         'graph',
         'doublearrow',
         'mint',
+        'deposit',
+        'withdraw',
     ];
 
     constructor(

--- a/src/app/services/raiden.service.spec.ts
+++ b/src/app/services/raiden.service.spec.ts
@@ -1626,7 +1626,7 @@ describe('RaidenService', () => {
 
     it('should request to set the total UDC deposit', fakeAsync(() => {
         service
-            .setUdcDeposit(new BigNumber(1000))
+            .depositToUdc(new BigNumber(1000))
             .subscribe((value) => expect(value).toBeFalsy());
 
         const request = mockHttp.expectOne({

--- a/src/app/services/raiden.service.spec.ts
+++ b/src/app/services/raiden.service.spec.ts
@@ -71,24 +71,12 @@ describe('RaidenService', () => {
     const paymentEvent = createPaymentEvent('EventPaymentReceivedSuccess');
 
     beforeEach(() => {
-        notificationService = jasmine.createSpyObj('NotificationService', [
-            'addPendingAction',
-            'removePendingAction',
-            'addSuccessNotification',
-            'addInfoNotification',
-            'addErrorNotification',
-        ]);
-        notificationService.apiError = null;
-
         TestBed.configureTestingModule({
             imports: [HttpClientModule, HttpClientTestingModule],
             providers: [
                 TestProviders.MockRaidenConfigProvider(),
                 RaidenService,
-                {
-                    provide: NotificationService,
-                    useValue: notificationService,
-                },
+                TestProviders.SpyNotificationServiceProvider(),
                 TokenInfoRetrieverService,
                 Web3Factory,
                 {

--- a/src/app/services/raiden.service.spec.ts
+++ b/src/app/services/raiden.service.spec.ts
@@ -1635,4 +1635,86 @@ describe('RaidenService', () => {
         });
         flush();
     }));
+
+    it('should request to set the total UDC deposit', fakeAsync(() => {
+        service
+            .setUdcDeposit(new BigNumber(1000))
+            .subscribe((value) => expect(value).toBeFalsy());
+
+        const request = mockHttp.expectOne({
+            url: `${endpoint}/user_deposit`,
+            method: 'POST',
+        });
+        expect(losslessParse(request.request.body)).toEqual({
+            total_deposit: new BigNumber(1000),
+        });
+
+        request.flush(
+            {
+                transaction_hash:
+                    '0xfc7edd195c6cc0c9391d84dd83b7aa9dbfffbcfc107e5c33a5ab912c0d92416c',
+            },
+            {
+                status: 200,
+                statusText: '',
+            }
+        );
+        tick();
+        flush();
+    }));
+
+    it('should request to plan a UDC withdraw', fakeAsync(() => {
+        service
+            .planUdcWithdraw(new BigNumber(500))
+            .subscribe((value) => expect(value).toBeFalsy());
+
+        const request = mockHttp.expectOne({
+            url: `${endpoint}/user_deposit`,
+            method: 'POST',
+        });
+        expect(losslessParse(request.request.body)).toEqual({
+            planned_withdraw_amount: new BigNumber(500),
+        });
+
+        request.flush(
+            {
+                transaction_hash:
+                    '0xfc7edd195c6cc0c9391d84dd83b7aa9dbfffbcfc107e5c33a5ab912c0d92416c',
+                planned_withdraw_block_number: 4269933,
+            },
+            {
+                status: 200,
+                statusText: '',
+            }
+        );
+        tick();
+        flush();
+    }));
+
+    it('should request to withdraw from UDC', fakeAsync(() => {
+        service
+            .withdrawFromUdc(new BigNumber(2222))
+            .subscribe((value) => expect(value).toBeFalsy());
+
+        const request = mockHttp.expectOne({
+            url: `${endpoint}/user_deposit`,
+            method: 'POST',
+        });
+        expect(losslessParse(request.request.body)).toEqual({
+            withdraw_amount: new BigNumber(2222),
+        });
+
+        request.flush(
+            {
+                transaction_hash:
+                    '0xfc7edd195c6cc0c9391d84dd83b7aa9dbfffbcfc107e5c33a5ab912c0d92416c',
+            },
+            {
+                status: 200,
+                statusText: '',
+            }
+        );
+        tick();
+        flush();
+    }));
 });

--- a/src/app/services/raiden.service.ts
+++ b/src/app/services/raiden.service.ts
@@ -813,6 +813,30 @@ export class RaidenService {
         );
     }
 
+    public setUdcDeposit(totalDeposit: BigNumber): Observable<void> {
+        return this.http
+            .post(`${this.raidenConfig.api}/user_deposit`, {
+                total_deposit: totalDeposit,
+            })
+            .pipe(mapTo(null));
+    }
+
+    public planUdcWithdraw(plannedWithdrawAmount: BigNumber): Observable<void> {
+        return this.http
+            .post(`${this.raidenConfig.api}/user_deposit`, {
+                planned_withdraw_amount: plannedWithdrawAmount,
+            })
+            .pipe(mapTo(null));
+    }
+
+    public withdrawFromUdc(withdrawAmount: BigNumber): Observable<void> {
+        return this.http
+            .post(`${this.raidenConfig.api}/user_deposit`, {
+                withdraw_amount: withdrawAmount,
+            })
+            .pipe(mapTo(null));
+    }
+
     public getStatus(): Observable<Status> {
         return this.http.get<Status>(`${this.raidenConfig.api}/status`).pipe(
             map((status) => {

--- a/src/app/services/raiden.service.ts
+++ b/src/app/services/raiden.service.ts
@@ -813,7 +813,7 @@ export class RaidenService {
         );
     }
 
-    public setUdcDeposit(totalDeposit: BigNumber): Observable<void> {
+    public depositToUdc(totalDeposit: BigNumber): Observable<void> {
         return this.http
             .post(`${this.raidenConfig.api}/user_deposit`, {
                 total_deposit: totalDeposit,

--- a/src/app/services/user-deposit.service.spec.ts
+++ b/src/app/services/user-deposit.service.spec.ts
@@ -44,7 +44,7 @@ describe('UserDepositService', () => {
         // @ts-ignore
         raidenServiceMock.rpcConnected$ = rpcConnectedSubject.asObservable();
         raidenServiceMock.getContractsInfo = () => of(createContractsInfo());
-        raidenServiceMock.setUdcDeposit = () => of(null);
+        raidenServiceMock.depositToUdc = () => of(null);
         raidenServiceMock.planUdcWithdraw = () => of(null);
         raidenServiceMock.withdrawFromUdc = () => of(null);
 
@@ -192,7 +192,7 @@ describe('UserDepositService', () => {
     it('should show notifications when depositing', fakeAsync(() => {
         const notificationService = TestBed.inject(NotificationService);
         const raidenService = TestBed.inject(RaidenService);
-        spyOn(raidenService, 'setUdcDeposit').and.callThrough();
+        spyOn(raidenService, 'depositToUdc').and.callThrough();
 
         const deposit = new BigNumber('666');
         service
@@ -205,8 +205,8 @@ describe('UserDepositService', () => {
             });
 
         tick();
-        expect(raidenService.setUdcDeposit).toHaveBeenCalledTimes(1);
-        expect(raidenService.setUdcDeposit).toHaveBeenCalledWith(
+        expect(raidenService.depositToUdc).toHaveBeenCalledTimes(1);
+        expect(raidenService.depositToUdc).toHaveBeenCalledWith(
             deposit.plus(totalDeposit)
         );
         expect(notificationService.addPendingAction).toHaveBeenCalledTimes(1);
@@ -273,7 +273,7 @@ describe('UserDepositService', () => {
     it('should show error notifications when deposit fails', fakeAsync(() => {
         const notificationService = TestBed.inject(NotificationService);
         const raidenService = TestBed.inject(RaidenService);
-        spyOn(raidenService, 'setUdcDeposit').and.returnValue(
+        spyOn(raidenService, 'depositToUdc').and.returnValue(
             throwError('Deposit failed')
         );
 

--- a/src/app/services/user-deposit.service.ts
+++ b/src/app/services/user-deposit.service.ts
@@ -87,7 +87,7 @@ export class UserDepositService {
             switchMapTo(totalDeposit$),
             switchMap((totalDeposit) => {
                 const newTotalDeposit = totalDeposit.plus(amount);
-                return this.raidenService.setUdcDeposit(newTotalDeposit);
+                return this.raidenService.depositToUdc(newTotalDeposit);
             }),
             tap(() => {
                 this.notificationService.addSuccessNotification({

--- a/src/assets/icons/deposit.svg
+++ b/src/assets/icons/deposit.svg
@@ -1,0 +1,5 @@
+<svg width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path d="M21 15L21 19C21 19.5304 20.7893 20.0391 20.4142 20.4142C20.0391 20.7893 19.5304 21 19 21L5 21C4.46957 21 3.96086 20.7893 3.58579 20.4142C3.21071 20.0391 3 19.5304 3 19L3 15" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+<path d="M7.7573 6.17161L7.7573 13.2427L14.8284 13.2427" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+<path d="M7.75739 13.2426L16.2427 4.75732" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+</svg>

--- a/src/assets/icons/withdraw.svg
+++ b/src/assets/icons/withdraw.svg
@@ -1,0 +1,5 @@
+<svg width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path d="M21 15L21 19C21 19.5304 20.7893 20.0391 20.4142 20.4142C20.0391 20.7893 19.5304 21 19 21L5 21C4.46957 21 3.96086 20.7893 3.58579 20.4142C3.21071 20.0391 3 19.5304 3 19L3 15" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+<path d="M16.7073 11.8284L16.7073 4.75732L9.63623 4.75732" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+<path d="M16.707 4.75739L8.22168 13.2427" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+</svg>

--- a/src/testing/test-providers.ts
+++ b/src/testing/test-providers.ts
@@ -10,6 +10,7 @@ import {
 } from '@angular/material/dialog';
 import { MockMatDialog } from './mock-mat-dialog';
 import { of } from 'rxjs';
+import { NotificationService } from 'app/services/notification.service';
 
 export class TestProviders {
     static AddressBookStubProvider(): Provider {
@@ -52,6 +53,26 @@ export class TestProviders {
         return {
             provide: MatDialog,
             useClass: MockMatDialog,
+        };
+    }
+
+    static SpyNotificationServiceProvider(): Provider {
+        return {
+            provide: NotificationService,
+            useFactory: () => {
+                const notificationService = jasmine.createSpyObj(
+                    'NotificationService',
+                    [
+                        'addPendingAction',
+                        'removePendingAction',
+                        'addSuccessNotification',
+                        'addInfoNotification',
+                        'addErrorNotification',
+                    ]
+                );
+                notificationService.apiError = undefined;
+                return notificationService;
+            },
         };
     }
 }


### PR DESCRIPTION
This PR adds methods for interacting with the new `/user_deposit` endpoint of the python client. This is needed for implementing the UDC dialog (#556). I wrapped these methods in the `UserDepositService` to provide a nice interface for the endpoint. Only there is the information (services token) accessible to show useful notifications to the user. 

There is one method each for depositing, planning a withdraw and withdrawing.