### PR TITLE
Fix error screen to show up after a API connection error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 
 ### Fixed
 - [#590] Fixed a bug that prevented to select the all networks view.
+- [#603] Error screen was not showing up when API connection failed.
 - [#598] Filters the address of the user account from the suggested connections when using Quick Connect.
 
 ## [1.1.1] - 2020-12-03
@@ -198,6 +199,7 @@ token network.
 [0.7.0]: https://github.com/raiden-network/webui/compare/v0.6.0...v0.7.0
 [0.6.0]: https://github.com/raiden-network/webui/releases/tag/v0.6.0
 
+[#603]: https://github.com/raiden-network/webui/issues/603
 [#598]: https://github.com/raiden-network/webui/issues/598
 [#590]: https://github.com/raiden-network/webui/issues/590
 [#580]: https://github.com/raiden-network/webui/issues/580

--- a/src/app/interceptors/error-handling.interceptor.spec.ts
+++ b/src/app/interceptors/error-handling.interceptor.spec.ts
@@ -31,6 +31,15 @@ describe('ErrorHandlingInterceptor', () => {
     let notificationService: NotificationService;
     let raidenConfig: RaidenConfig;
 
+    const httpResponse400 = {
+        status: 400,
+        statusText: '',
+    };
+    const httpResponse504 = {
+        status: 504,
+        statusText: '',
+    };
+
     beforeEach(() => {
         TestBed.configureTestingModule({
             imports: [HttpClientTestingModule],
@@ -67,10 +76,7 @@ describe('ErrorHandlingInterceptor', () => {
             errors: errorMessage,
         };
 
-        request.flush(errorBody, {
-            status: 400,
-            statusText: '',
-        });
+        request.flush(errorBody, httpResponse400);
         tick();
         expect(errorSpy).toHaveBeenCalledTimes(1);
         expect(errorSpy).toHaveBeenCalledWith(errorMessage);
@@ -93,10 +99,7 @@ describe('ErrorHandlingInterceptor', () => {
             ],
         };
 
-        request.flush(errorBody, {
-            status: 400,
-            statusText: '',
-        });
+        request.flush(errorBody, httpResponse400);
         tick();
         expect(errorSpy).toHaveBeenCalledTimes(1);
         expect(errorSpy).toHaveBeenCalledWith(errorMessage);
@@ -115,10 +118,7 @@ describe('ErrorHandlingInterceptor', () => {
             errors: '',
         };
 
-        request.flush(errorBody, {
-            status: 400,
-            statusText: '',
-        });
+        request.flush(errorBody, httpResponse400);
         tick();
         expect(errorSpy).toHaveBeenCalledTimes(1);
         expect(errorSpy).toHaveBeenCalledWith(errorMessage);
@@ -132,18 +132,13 @@ describe('ErrorHandlingInterceptor', () => {
 
         let request = httpMock.expectOne(raidenConfig.api);
 
-        request.flush(
-            {},
-            {
-                status: 504,
-                statusText: '',
-            }
-        );
+        request.flush({}, httpResponse504);
         tick();
 
         expect(notificationService.addErrorNotification).toHaveBeenCalledTimes(
             1
         );
+        expect(notificationService.apiError).toBeTruthy();
         expect(errorSpy).toHaveBeenCalledTimes(1);
 
         service.getData().subscribe(() => {
@@ -162,6 +157,7 @@ describe('ErrorHandlingInterceptor', () => {
         expect(notificationService.addErrorNotification).toHaveBeenCalledTimes(
             1
         );
+        expect(notificationService.apiError).toBeTruthy();
         expect(errorSpy).toHaveBeenCalledTimes(2);
     }));
 
@@ -173,32 +169,21 @@ describe('ErrorHandlingInterceptor', () => {
 
         let request = httpMock.expectOne(raidenConfig.api);
 
-        request.flush(
-            {},
-            {
-                status: 504,
-                statusText: '',
-            }
-        );
-
+        request.flush({}, httpResponse504);
         tick();
+
         notificationService.apiError.retrying = true;
         service.getData().subscribe(() => {
             fail('On next should not be called');
         }, errorSpy);
         request = httpMock.expectOne(raidenConfig.api);
-        request.flush(
-            {},
-            {
-                status: 504,
-                statusText: '',
-            }
-        );
+        request.flush({}, httpResponse504);
         tick();
 
         expect(notificationService.addErrorNotification).toHaveBeenCalledTimes(
             2
         );
+        expect(notificationService.apiError).toBeTruthy();
         expect(errorSpy).toHaveBeenCalledTimes(2);
     }));
 
@@ -217,13 +202,7 @@ describe('ErrorHandlingInterceptor', () => {
 
         let request = httpMock.expectOne(raidenConfig.api);
 
-        request.flush(
-            {},
-            {
-                status: 504,
-                statusText: '',
-            }
-        );
+        request.flush({}, httpResponse504);
         tick();
 
         service.getData().subscribe((data) => {
@@ -257,18 +236,13 @@ describe('ErrorHandlingInterceptor', () => {
         }, errorSpy);
 
         const request = httpMock.expectOne(requestUrl);
-        request.flush(
-            {},
-            {
-                status: 504,
-                statusText: '',
-            }
-        );
+        request.flush({}, httpResponse504);
         tick();
 
         expect(notificationService.addErrorNotification).toHaveBeenCalledTimes(
             1
         );
+        expect(notificationService.apiError).toBeTruthy();
         expect(errorSpy).toHaveBeenCalledTimes(1);
     }));
 
@@ -282,13 +256,7 @@ describe('ErrorHandlingInterceptor', () => {
         }, errorSpy);
 
         const request = httpMock.expectOne(requestUrl);
-        request.flush(
-            {},
-            {
-                status: 504,
-                statusText: '',
-            }
-        );
+        request.flush({}, httpResponse504);
         tick();
 
         expect(notificationService.addErrorNotification).toHaveBeenCalledTimes(

--- a/src/app/interceptors/error-handling.interceptor.ts
+++ b/src/app/interceptors/error-handling.interceptor.ts
@@ -30,7 +30,7 @@ export class ErrorHandlingInterceptor implements HttpInterceptor {
             tap((event) => {
                 if (
                     event instanceof HttpResponse &&
-                    event.url.startsWith(this.raidenConfig.api) &&
+                    this.isRaidenApiUrl(event.url) &&
                     this.notificationService.apiError
                 ) {
                     this.raidenService.attemptRpcConnection();
@@ -47,7 +47,7 @@ export class ErrorHandlingInterceptor implements HttpInterceptor {
 
         if (
             error instanceof HttpErrorResponse &&
-            error.url.startsWith(this.raidenConfig.api) &&
+            this.isRaidenApiUrl(error.url) &&
             (error.status === 504 || error.status === 0)
         ) {
             errMsg = 'Could not connect to the Raiden API';
@@ -93,5 +93,12 @@ export class ErrorHandlingInterceptor implements HttpInterceptor {
 
         console.error(errMsg);
         return throwError(errMsg);
+    }
+
+    private isRaidenApiUrl(url: string): boolean {
+        return (
+            url.startsWith(this.raidenConfig.api) ||
+            url.startsWith(window.location.origin + this.raidenConfig.api)
+        );
     }
 }


### PR DESCRIPTION
Fixes #603 

The `ErrorHandlingInterceptor` was not matching the Raiden API URL correctly. This resulted in not showing the error screen when the connection failed. 
The problem was that it was just checking if the complete url of a `HttpResponse` was matching the Raiden API URL. But in most cases the Raiden API URL is stored only as the path of the url (`/api/v1/`) without a host.

This also makes it possible to retry connecting to the status endpoint. This was missing because of it being called only once during startup.