### PR TITLE
Filter user account's address from quick connect suggestions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 
 ### Fixed
 - [#590] Fixed a bug that prevented to select the all networks view.
+- [#598] Filters the address of the user account from the suggested connections when using Quick Connect.
 
 ## [1.1.1] - 2020-12-03
 ### Fixed
@@ -197,6 +198,7 @@ token network.
 [0.7.0]: https://github.com/raiden-network/webui/compare/v0.6.0...v0.7.0
 [0.6.0]: https://github.com/raiden-network/webui/releases/tag/v0.6.0
 
+[#598]: https://github.com/raiden-network/webui/issues/598
 [#590]: https://github.com/raiden-network/webui/issues/590
 [#580]: https://github.com/raiden-network/webui/issues/580
 [#557]: https://github.com/raiden-network/webui/issues/557

--- a/src/app/components/quick-connect-dialog/connection-selector/connection-selector.component.spec.ts
+++ b/src/app/components/quick-connect-dialog/connection-selector/connection-selector.component.spec.ts
@@ -26,7 +26,7 @@ import { amountToDecimal } from 'app/utils/amount.converter';
 import BigNumber from 'bignumber.js';
 import { ClipboardModule } from 'ngx-clipboard';
 import { clickElement, mockInput } from 'testing/interaction-helper';
-import { createSuggestedConnections, createToken } from 'testing/test-data';
+import { createTestSuggestedConnections, createToken } from 'testing/test-data';
 import { TestProviders } from 'testing/test-providers';
 import { ConnectionSelectorComponent } from './connection-selector.component';
 
@@ -40,7 +40,7 @@ describe('ConnectionSelectorComponent', () => {
         balance: new BigNumber('10000000000000000000'),
     });
     const totalAmount = new BigNumber('3000000000000000000');
-    const suggestions = createSuggestedConnections();
+    const suggestions = createTestSuggestedConnections();
 
     function initComponentForFakeAsync() {
         fixture.detectChanges();

--- a/src/app/components/quick-connect-dialog/quick-connect-dialog.component.spec.ts
+++ b/src/app/components/quick-connect-dialog/quick-connect-dialog.component.spec.ts
@@ -41,7 +41,8 @@ import {
     createAddress,
     createChannel,
     createSettings,
-    createSuggestedConnections,
+    createSuggestedConnection,
+    createTestSuggestedConnections,
     createToken,
 } from 'testing/test-data';
 import { TestProviders } from 'testing/test-providers';
@@ -59,7 +60,7 @@ describe('QuickConnectDialogComponent', () => {
     let component: QuickConnectDialogComponent;
     let fixture: ComponentFixture<QuickConnectDialogComponent>;
 
-    const suggestions = createSuggestedConnections();
+    const suggestions = createTestSuggestedConnections();
     const token = createToken({
         decimals: 0,
         balance: new BigNumber(1000),
@@ -69,6 +70,7 @@ describe('QuickConnectDialogComponent', () => {
         },
     });
     const tokenNetworkAddress = createAddress();
+    const raidenAddress = createAddress();
     const settings = createSettings();
     const totalAmountInput = '70';
     const totalAmountValue = amountFromDecimal(
@@ -83,6 +85,9 @@ describe('QuickConnectDialogComponent', () => {
         const raidenService = TestBed.inject(RaidenService);
         spyOn(raidenService, 'getTokenNetworkAddress').and.returnValue(
             of(tokenNetworkAddress)
+        );
+        spyOnProperty(raidenService, 'raidenAddress').and.returnValue(
+            raidenAddress
         );
         settingsSubject = new BehaviorSubject(settings);
         spyOn(raidenService, 'getSettings').and.returnValue(
@@ -258,6 +263,19 @@ describe('QuickConnectDialogComponent', () => {
                 suggestions.length - 1
             );
             expect(component.suggestions).toEqual(suggestions.slice(1));
+        }));
+
+        it('should filter the suggestions by the address of the user account', fakeAsync(() => {
+            const suggestedConnections = [
+                createSuggestedConnection({ address: raidenAddress }),
+                createSuggestedConnection(),
+            ];
+            initComponentForFakeAsync(suggestedConnections);
+
+            expect(component.suggestions.length).toEqual(1);
+            expect(component.suggestions).toEqual(
+                suggestedConnections.slice(1)
+            );
         }));
 
         it('should show an error if there are no suggestions', fakeAsync(() => {

--- a/src/app/components/quick-connect-dialog/quick-connect-dialog.component.ts
+++ b/src/app/components/quick-connect-dialog/quick-connect-dialog.component.ts
@@ -9,14 +9,7 @@ import { ChannelPollingService } from 'app/services/channel-polling.service';
 import { RaidenService } from 'app/services/raiden.service';
 import { TokenPollingService } from 'app/services/token-polling.service';
 import BigNumber from 'bignumber.js';
-import {
-    combineLatest,
-    EMPTY,
-    Observable,
-    Subject,
-    throwError,
-    zip,
-} from 'rxjs';
+import { combineLatest, EMPTY, Observable, Subject, zip } from 'rxjs';
 import {
     catchError,
     delay,
@@ -160,14 +153,16 @@ export class QuickConnectDialogComponent implements OnInit, OnDestroy {
         zip(suggestions$, existingChannels$)
             .pipe(
                 map(([suggestions, channels]) =>
-                    suggestions.filter(
-                        (suggestion) =>
-                            !channels.find(
-                                (channel) =>
-                                    channel.partner_address ===
-                                    suggestion.address
-                            )
-                    )
+                    suggestions.filter((suggestion) => {
+                        const channelExisting = !!channels.find(
+                            (channel) =>
+                                channel.partner_address === suggestion.address
+                        );
+                        const isOwnAddress =
+                            suggestion.address ===
+                            this.raidenService.raidenAddress;
+                        return !channelExisting && !isOwnAddress;
+                    })
                 ),
                 catchError((error, caught) => {
                     this.loading = false;

--- a/src/testing/test-data.ts
+++ b/src/testing/test-data.ts
@@ -192,18 +192,23 @@ export function createContractsInfo(obj: any = {}): ContractsInfo {
     return Object.assign(contracts, obj);
 }
 
-export function createSuggestedConnections(
+export function createSuggestedConnection(obj: any = {}): SuggestedConnection {
+    const suggestedConnection: SuggestedConnection = {
+        address: createAddress(),
+        score: BigNumber.random(19).times(10 ** 19),
+        centrality: BigNumber.random(21),
+        uptime: BigNumber.random(5).times(10 ** 5),
+        capacity: BigNumber.random(19).times(10 ** 19),
+    };
+    return Object.assign(suggestedConnection, obj);
+}
+
+export function createTestSuggestedConnections(
     count: number = 5
 ): SuggestedConnection[] {
     const suggestions: SuggestedConnection[] = [];
     for (let i = 0; i < count; i++) {
-        suggestions.push({
-            address: createAddress(),
-            score: BigNumber.random(19).times(10 ** 19),
-            centrality: BigNumber.random(21),
-            uptime: BigNumber.random(5).times(10 ** 5),
-            capacity: BigNumber.random(19).times(10 ** 19),
-        });
+        suggestions.push(createSuggestedConnection());
     }
     suggestions.sort((a, b) => a.score.minus(b.score).toNumber());
     return suggestions;


### PR DESCRIPTION
Fixes #598 

The Quick Connect dialog could show the address of the user account as a suggestion for creating a channel. This PR filters the suggestions that are returned from the PFS by the user account's address.