### PR TITLE
Introduce versioning for CircleCI cache key to invalidate old caches

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -9,7 +9,7 @@ templates:
 
 
 var_1: &docker_image circleci/node:lts-browsers
-var_2: &cache_key raiden-webui-{{ .Branch }}-{{ checksum "yarn.lock" }}
+var_2: &cache_key raiden-webui-deps-v1-{{ .Branch }}-{{ checksum "yarn.lock" }}
 
 anchor_1: &root_yarn_lock_key
   key: *cache_key


### PR DESCRIPTION
This introduces a change in the CI cache key to invalidate old caches. This is necessary because of the Codecov security breach (https://github.com/raiden-network/team/issues/933).