### PR TITLE
Bump version: 1.1.1 → 1.2.0

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 1.1.1
+current_version = 1.2.0
 commit = True
 tag = False
 parse = (?P<major>\d+)\.(?P<minor>\d+)\.(?P<patch>\d+)(\-(?P<release>[a-z]+)(?P<build>\d+))?

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 # Changelog
 
 ## [Unreleased]
+
+## [1.2.0] - 2020-04-26
 ### Added
 - [#556] New dialog for interacting with the UDC. The dialog enables depositing and withdrawing tokens.
 - [#195] Services tokens can be minted from the UDC dialog.
@@ -179,7 +181,8 @@ token network.
 ### Changed
 - First python package release.
 
-[Unreleased]: https://github.com/raiden-network/webui/compare/v1.1.1...HEAD
+[Unreleased]: https://github.com/raiden-network/webui/compare/v1.2.0...HEAD
+[1.2.0]: https://github.com/raiden-network/webui/compare/v1.1.1...v1.2.0
 [1.1.1]: https://github.com/raiden-network/webui/compare/v1.1.0...v1.1.1
 [1.1.0]: https://github.com/raiden-network/webui/compare/v1.0.2...v1.1.0
 [1.0.2]: https://github.com/raiden-network/webui/compare/v1.0.1...v1.0.2

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "raiden-webui",
-  "version": "1.1.1",
+  "version": "1.2.0",
   "license": "MIT",
   "scripts": {
     "preinstall": "npx only-allow yarn",

--- a/setup.py
+++ b/setup.py
@@ -72,7 +72,7 @@ with open('README.md', encoding='utf-8') as readme_file:
 
 history = ''
 
-version = '1.1.1'  # Do not edit: this is maintained by bumpversion (see .bumpversion.cfg)
+version = '1.2.0'  # Do not edit: this is maintained by bumpversion (see .bumpversion.cfg)
 
 setup(
     name='raiden-webui',

--- a/src/version.ts
+++ b/src/version.ts
@@ -1,2 +1,2 @@
 // Do not change this, this is maintained by bumpversion.
-export const version = '1.1.1';
+export const version = '1.2.0';


### PR DESCRIPTION
New release with the UDC dialog and some bugfixes.