### PR TITLE
Fix CI build and bump version 1.2.0 → 1.2.1

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 1.2.0
+current_version = 1.2.1
 commit = True
 tag = False
 parse = (?P<major>\d+)\.(?P<minor>\d+)\.(?P<patch>\d+)(\-(?P<release>[a-z]+)(?P<build>\d+))?

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+## [1.2.1] - 2020-04-26
+### Fixed
+- Fixed a problem in the build process of v1.2.0.
+
 ## [1.2.0] - 2020-04-26
 ### Added
 - [#556] New dialog for interacting with the UDC. The dialog enables depositing and withdrawing tokens.
@@ -181,7 +185,8 @@ token network.
 ### Changed
 - First python package release.
 
-[Unreleased]: https://github.com/raiden-network/webui/compare/v1.2.0...HEAD
+[Unreleased]: https://github.com/raiden-network/webui/compare/v1.2.1...HEAD
+[1.2.1]: https://github.com/raiden-network/webui/compare/v1.2.0...v1.2.1
 [1.2.0]: https://github.com/raiden-network/webui/compare/v1.1.1...v1.2.0
 [1.1.1]: https://github.com/raiden-network/webui/compare/v1.1.0...v1.1.1
 [1.1.0]: https://github.com/raiden-network/webui/compare/v1.0.2...v1.1.0

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "raiden-webui",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "license": "MIT",
   "scripts": {
     "preinstall": "npx only-allow yarn",

--- a/setup.py
+++ b/setup.py
@@ -30,7 +30,11 @@ class CompileWebUI(Command):
     def run(self):
         yarn = find_executable('yarn')
         if not yarn:
-            raise RuntimeError('Yarn not found. Aborting')
+            self.announce(
+                'Yarn not found. Skipping webUI compilation',
+                level=distutils.log.WARN,  # pylint: disable=no-member
+            )
+            return
 
         yarn_run = 'build:prod'
         if self.dev is not None:

--- a/setup.py
+++ b/setup.py
@@ -76,7 +76,7 @@ with open('README.md', encoding='utf-8') as readme_file:
 
 history = ''
 
-version = '1.2.0'  # Do not edit: this is maintained by bumpversion (see .bumpversion.cfg)
+version = '1.2.1'  # Do not edit: this is maintained by bumpversion (see .bumpversion.cfg)
 
 setup(
     name='raiden-webui',

--- a/src/version.ts
+++ b/src/version.ts
@@ -1,2 +1,2 @@
 // Do not change this, this is maintained by bumpversion.
-export const version = '1.2.0';
+export const version = '1.2.1';


### PR DESCRIPTION
The build of v1.2.0 was failing in the CI because the build process required to have yarn installed. When I changed the project to use yarn instead of npm I made this check required in the `setup.py`. Before it was just skipping the webui compilation if npm was not installed. The compilation is done in a previous job in the CI so it is not needed. The build package job does not have yarn installed because it is using the python image. This PR makes the compilation in the build process optional again. I also bumped the version to quickly make a new release. The changes in the `setup.py` were tested on the failed CI job via ssh.