### PR TITLE
Update docs links to use readthedocs

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,7 +88,7 @@ If you haven't used Raiden before, you can:
 
 ### Using the WebUI
 
-If you want to learn how to use the Raiden WebUI an [updated tutorial](https://docs.raiden.network/the-raiden-web-interface) has been published in the new documentation for Raiden.
+If you want to learn how to use the Raiden WebUI an [updated tutorial](https://raiden-network.readthedocs.io/en/latest/the-raiden-web-interface/the-raiden-web-interface.html) has been published in the documentation for Raiden.
 
 ### Prerequisites
 
@@ -96,12 +96,12 @@ If you just want to use the WebUI all you need to do is install and run Raiden. 
 
 For details on how to easily install Raiden:
 
-Read the [Quick Start](https://docs.raiden.network/quick-start) section in the documentation.
+Read the [Quick Start](https://raiden-network.readthedocs.io/en/stable/installation/quick-start/) section in the documentation.
 
 If you want to work on the WebUI codebase you need:
 
 -   Node >=10.13.0
--   A working [Raiden client](https://raiden-network.readthedocs.io/en/latest/overview_and_guide.html).
+-   A working [Raiden client](https://raiden-network.readthedocs.io/en/latest/overview_and_guide.html#installation).
 -   Git for version control.
 -   Yarn v1 for package management.
 

--- a/src/app/components/token-input/token-input.component.html
+++ b/src/app/components/token-input/token-input.component.html
@@ -83,7 +83,7 @@
             Below recommended limit of {{ formattedThreshold() }}
             {{ selectedToken.symbol }} for mediated transfers.
             <a
-                href="https://docs.raiden.network/using-raiden-on-mainnet/mediation-fees"
+                href="https://raiden-network.readthedocs.io/en/latest/using-raiden-on-mainnet/overview.html#mediation-fees"
                 target="_blank"
                 class="info-link"
             >


### PR DESCRIPTION
As our documentation was completely moved to readthedocs, this updates all links to it.