### PR TITLE
Metamask integration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 # Changelog
 
 ## [Unreleased]
+### Added
+- [#655] Integrated MetaMask for easily filling up the Raiden account with ETH and tokens.
 
 ## [1.2.1] - 2020-04-26
 ### Fixed
@@ -208,6 +210,7 @@ token network.
 [0.7.0]: https://github.com/raiden-network/webui/compare/v0.6.0...v0.7.0
 [0.6.0]: https://github.com/raiden-network/webui/releases/tag/v0.6.0
 
+[#655]: https://github.com/raiden-network/webui/issues/655
 [#603]: https://github.com/raiden-network/webui/issues/603
 [#598]: https://github.com/raiden-network/webui/issues/598
 [#590]: https://github.com/raiden-network/webui/issues/590

--- a/angular.json
+++ b/angular.json
@@ -39,6 +39,14 @@
                         }
                     },
                     "configurations": {
+                        "development": {
+                            "vendorChunk": true,
+                            "extractLicenses": false,
+                            "buildOptimizer": false,
+                            "sourceMap": true,
+                            "optimization": false,
+                            "namedChunks": true
+                        },
                         "production": {
                             "budgets": [
                                 {
@@ -61,16 +69,18 @@
                                 }
                             ]
                         }
-                    }
+                    },
+                    "defaultConfiguration": "production"
                 },
                 "serve": {
                     "builder": "@angular-builders/custom-webpack:dev-server",
-                    "options": {
-                        "browserTarget": "raidenwebui:build"
+                    "defaultConfiguration": "",
+                    "options": {    
+                        "browserTarget": "raidenwebui:build:development"
                     },
                     "configurations": {
                         "production": {
-                            "browserTarget": "raidenwebui:build:production"
+                            "browserTarget": "raidenwebui:build:development"
                         }
                     }
                 },

--- a/angular.json
+++ b/angular.json
@@ -75,7 +75,7 @@
                 "serve": {
                     "builder": "@angular-builders/custom-webpack:dev-server",
                     "defaultConfiguration": "",
-                    "options": {    
+                    "options": {
                         "browserTarget": "raidenwebui:build:development"
                     },
                     "configurations": {

--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
     "@angular/platform-browser": "12.1.4",
     "@angular/platform-browser-dynamic": "12.1.4",
     "@angular/router": "12.1.4",
+    "@metamask/detect-provider": "^1.2.0",
     "ajv": "8.6.2",
     "assert": "2.0.0",
     "bignumber.js": "9.0.1",

--- a/src/app/app.component.spec.ts
+++ b/src/app/app.component.spec.ts
@@ -50,6 +50,7 @@ import { MatSidenav } from '@angular/material/sidenav';
 import { DecimalPipe } from './pipes/decimal.pipe';
 import { BalanceWithSymbolComponent } from './components/balance-with-symbol/balance-with-symbol.component';
 import { TokenNetworkSelectorComponent } from './components/token-network-selector/token-network-selector.component';
+import { ShortenAddressPipe } from './pipes/shorten-address.pipe';
 
 describe('AppComponent', () => {
     let fixture: ComponentFixture<AppComponent>;
@@ -116,6 +117,7 @@ describe('AppComponent', () => {
                     DecimalPipe,
                     BalanceWithSymbolComponent,
                     TokenNetworkSelectorComponent,
+                    ShortenAddressPipe,
                 ],
                 providers: [
                     TestProviders.MockRaidenConfigProvider(),

--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -68,6 +68,7 @@ import { ConnectionSelectorComponent } from './components/quick-connect-dialog/c
 import { UserDepositDialogComponent } from './components/user-deposit-dialog/user-deposit-dialog.component';
 import { DepositWithdrawFormComponent } from './components/user-deposit-dialog/deposit-withdraw-form/deposit-withdraw-form.component';
 import { ShortenAddressPipe } from './pipes/shorten-address.pipe';
+import { AccountDialogComponent } from './components/account-dialog/account-dialog.component';
 
 const appRoutes: Routes = [
     { path: '', redirectTo: '/home', pathMatch: 'full' },
@@ -128,6 +129,7 @@ export function ConfigLoader(raidenConfig: RaidenConfig) {
         UserDepositDialogComponent,
         DepositWithdrawFormComponent,
         ShortenAddressPipe,
+        AccountDialogComponent,
     ],
     imports: [
         RouterModule.forRoot(appRoutes, { relativeLinkResolution: 'legacy' }),

--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -67,6 +67,7 @@ import { QuickConnectDialogComponent } from './components/quick-connect-dialog/q
 import { ConnectionSelectorComponent } from './components/quick-connect-dialog/connection-selector/connection-selector.component';
 import { UserDepositDialogComponent } from './components/user-deposit-dialog/user-deposit-dialog.component';
 import { DepositWithdrawFormComponent } from './components/user-deposit-dialog/deposit-withdraw-form/deposit-withdraw-form.component';
+import { ShortenAddressPipe } from './pipes/shorten-address.pipe';
 
 const appRoutes: Routes = [
     { path: '', redirectTo: '/home', pathMatch: 'full' },
@@ -126,6 +127,7 @@ export function ConfigLoader(raidenConfig: RaidenConfig) {
         ConnectionSelectorComponent,
         UserDepositDialogComponent,
         DepositWithdrawFormComponent,
+        ShortenAddressPipe,
     ],
     imports: [
         RouterModule.forRoot(appRoutes, { relativeLinkResolution: 'legacy' }),

--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -15,7 +15,7 @@ import { OpenDialogComponent } from './components/open-dialog/open-dialog.compon
 import { PaymentDialogComponent } from './components/payment-dialog/payment-dialog.component';
 import { RegisterDialogComponent } from './components/register-dialog/register-dialog.component';
 import { MaterialComponentsModule } from './modules/material-components/material-components.module';
-import { RaidenConfig, Web3Factory } from './services/raiden.config';
+import { RaidenConfig } from './services/raiden.config';
 import { LosslessJsonInterceptor } from './interceptors/lossless-json.interceptor';
 import { TimeoutInterceptor } from './interceptors/timeout.interceptor';
 import { ErrorHandlingInterceptor } from './interceptors/error-handling.interceptor';
@@ -69,6 +69,7 @@ import { UserDepositDialogComponent } from './components/user-deposit-dialog/use
 import { DepositWithdrawFormComponent } from './components/user-deposit-dialog/deposit-withdraw-form/deposit-withdraw-form.component';
 import { ShortenAddressPipe } from './pipes/shorten-address.pipe';
 import { AccountDialogComponent } from './components/account-dialog/account-dialog.component';
+import { Web3Factory } from './services/web3-factory.service';
 
 const appRoutes: Routes = [
     { path: '', redirectTo: '/home', pathMatch: 'full' },

--- a/src/app/components/account-dialog/account-dialog.component.html
+++ b/src/app/components/account-dialog/account-dialog.component.html
@@ -1,0 +1,82 @@
+<app-raiden-dialog
+    acceptText="Done"
+    infoText="You can use this dialog to top up your account with ETH or tokens from a wallet."
+    [showCancel]="false"
+    [formGroup]="form"
+    (accept)="close()"
+    (cancel)="close()"
+>
+    <div fxLayout="column" fxLayoutAlign="start center" fxLayoutGap="16px">
+        <app-token-network-selector
+            class="token-selector"
+            formControlName="asset"
+            [showOnChainBalance]="true"
+            [showEthOption]="true"
+            [showServicesToken]="true"
+            triggerText="Change Asset"
+            selectorClass="mat-select--dark"
+        ></app-token-network-selector>
+        <div class="info" fxLayout="column" fxLayoutAlign="start center">
+            <div fxLayout="row" fxLayoutGap="8px" fxLayoutAlign="center center">
+                <div
+                    class="info__balance"
+                    *ngIf="ethSelected; else token_balance"
+                >
+                    <span
+                        [matTooltip]="ethBalance$ | async"
+                        class="info__balance info__balance--limited"
+                    >
+                        {{ ethBalance$ | async | displayDecimals: 3 }}
+                    </span>
+                    <span class="info__balance info__balance--uppercase">
+                        ETH
+                    </span>
+                </div>
+                <ng-template #token_balance>
+                    <app-balance-with-symbol
+                        class="info__balance"
+                        [balance]="balance"
+                        [token]="token"
+                        [maxBalanceWidth]="200"
+                    ></app-balance-with-symbol>
+                </ng-template>
+                <span
+                    *ngIf="ethSelected && zeroEthBalance$ | async"
+                    class="info__alert"
+                    fxLayoutAlign="center center"
+                >
+                    <mat-icon
+                        svgIcon="down-arrow"
+                        aria-label="Funds needed"
+                        class="info__icon"
+                        matTooltip="Funds needed"
+                    ></mat-icon>
+                </span>
+                <a
+                    *ngIf="ethSelected && (network$ | async)?.faucet"
+                    [href]="faucetLink$ | async"
+                    target="_blank"
+                    mat-icon-button
+                    class="info__button"
+                    matTooltip="Open ether faucet"
+                    fxLayout="column"
+                    fxLayoutAlign="center center"
+                    fxFlexAlign="center"
+                    id="faucet-button"
+                >
+                    <mat-icon
+                        class="info__small-icon"
+                        svgIcon="faucet"
+                        aria-label="Open ether faucet"
+                    >
+                    </mat-icon>
+                </a>
+            </div>
+            <span class="info__label">On-chain balance</span>
+        </div>
+        <span class="info__label info__label--white">
+            Send {{ ethSelected ? 'ETH' : token.symbol }} to your account
+        </span>
+        <app-token-input formControlName="amount"></app-token-input>
+    </div>
+</app-raiden-dialog>

--- a/src/app/components/account-dialog/account-dialog.component.html
+++ b/src/app/components/account-dialog/account-dialog.component.html
@@ -1,9 +1,15 @@
 <app-raiden-dialog
-    acceptText="Done"
+    [acceptText]="
+        defaultAccount
+            ? 'Send ' + (ethSelected ? 'ETH' : token.symbol)
+            : 'Connect Wallet'
+    "
+    [acceptDisabled]="!web3 || (defaultAccount && form.invalid)"
     infoText="You can use this dialog to top up your account with ETH or tokens from a wallet."
     [showCancel]="false"
     [formGroup]="form"
-    (accept)="close()"
+    [noButtons]="requesting"
+    (accept)="accept()"
     (cancel)="close()"
 >
     <div fxLayout="column" fxLayoutAlign="start center" fxLayoutGap="16px">
@@ -77,6 +83,27 @@
         <span class="info__label info__label--white">
             Send {{ ethSelected ? 'ETH' : token.symbol }} to your account
         </span>
-        <app-token-input formControlName="amount"></app-token-input>
+        <app-token-input
+            class="token-input"
+            formControlName="amount"
+        ></app-token-input>
+        <mat-progress-spinner
+            *ngIf="requesting"
+            diameter="38"
+            mode="indeterminate"
+            color="accent"
+        ></mat-progress-spinner>
+        <div class="error-box" [@fallDown]="'in'">
+            <span *ngIf="!web3">
+                Could not detect wallet. You need MetaMask to proceed.
+            </span>
+            <span *ngIf="wrongChainID" class="error-box__item">
+                The chain ids of your Web3 provider and your Raiden client do
+                not match.
+            </span>
+            <span *ngIf="accountRequestRejected" class="error-box__item">
+                Access to accounts rejected.
+            </span>
+        </div>
     </div>
 </app-raiden-dialog>

--- a/src/app/components/account-dialog/account-dialog.component.scss
+++ b/src/app/components/account-dialog/account-dialog.component.scss
@@ -1,0 +1,60 @@
+@import '../../../sass/colors';
+
+.info {
+    &__balance {
+        font-weight: 500;
+        font-size: 26px;
+        line-height: 32px;
+        padding: 3.5px 0;
+        color: $white;
+
+        &--uppercase {
+            text-transform: uppercase;
+        }
+
+        &--limited {
+            white-space: nowrap;
+            overflow: hidden;
+            text-overflow: ellipsis;
+            max-width: 200px;
+        }
+    }
+
+    &__label {
+        font-size: 12px;
+        line-height: 15px;
+        letter-spacing: 0.04em;
+        text-transform: uppercase;
+
+        &--white {
+            color: $white;
+        }
+    }
+
+    &__alert {
+        width: 22px;
+        height: 22px;
+        border-radius: 50%;
+        background-color: $bg-label-red;
+        color: $label-red;
+    }
+
+    &__button {
+        height: 22px !important;
+        width: 22px !important;
+        background-color: $bg-dark-light-grey;
+        color: $light-grey;
+    }
+
+    &__icon {
+        height: 16px !important;
+        width: 16px !important;
+        line-height: 16px;
+    }
+
+    &__small-icon {
+        height: 14px !important;
+        width: 14px !important;
+        line-height: 14px;
+    }
+}

--- a/src/app/components/account-dialog/account-dialog.component.scss
+++ b/src/app/components/account-dialog/account-dialog.component.scss
@@ -58,3 +58,21 @@
         line-height: 14px;
     }
 }
+
+.token-input {
+    width: 224px;
+}
+
+.error-box {
+    width: 100%;
+    font-size: 12px;
+    line-height: 15px;
+    color: $red;
+    text-align: center;
+    overflow: hidden;
+    text-overflow: ellipsis;
+
+    &__item {
+        height: 32px;
+    }
+}

--- a/src/app/components/account-dialog/account-dialog.component.spec.ts
+++ b/src/app/components/account-dialog/account-dialog.component.spec.ts
@@ -1,0 +1,45 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { AccountDialogComponent } from './account-dialog.component';
+
+describe('AccountDialogComponent', () => {
+    let component: AccountDialogComponent;
+    let fixture: ComponentFixture<AccountDialogComponent>;
+
+    beforeEach(async () => {
+        await TestBed.configureTestingModule({
+            declarations: [AccountDialogComponent],
+        }).compileComponents();
+    });
+
+    beforeEach(() => {
+        fixture = TestBed.createComponent(AccountDialogComponent);
+        component = fixture.componentInstance;
+        fixture.detectChanges();
+    });
+
+    it('should create', () => {
+        expect(component).toBeTruthy();
+    });
+
+    // it('should have a faucet button when network has a faucet', () => {
+    //     expect(
+    //         fixture.debugElement.query(By.css('#faucet-button'))
+    //     ).toBeTruthy();
+    // });
+
+    // it('should not have a faucet button when network does not have a faucet', () => {
+    //     networkSubject.next(createNetworkMock({ faucet: null }));
+    //     fixture.detectChanges();
+    //     expect(
+    //         fixture.debugElement.query(By.css('#faucet-button'))
+    //     ).toBeFalsy();
+    // });
+
+    // it('should insert the address correctly into the href attribute of the faucet button', () => {
+    //     const href = fixture.debugElement
+    //         .query(By.css('#faucet-button'))
+    //         .nativeElement.getAttribute('href');
+    //     expect(href).toBe(`http://faucet.test/?${raidenAddress}`);
+    // });
+});

--- a/src/app/components/account-dialog/account-dialog.component.spec.ts
+++ b/src/app/components/account-dialog/account-dialog.component.spec.ts
@@ -1,45 +1,358 @@
-import { ComponentFixture, TestBed } from '@angular/core/testing';
-
-import { AccountDialogComponent } from './account-dialog.component';
+import { HttpClientTestingModule } from '@angular/common/http/testing';
+import {
+    ComponentFixture,
+    fakeAsync,
+    flush,
+    TestBed,
+    tick,
+} from '@angular/core/testing';
+import { ReactiveFormsModule } from '@angular/forms';
+import { NoopAnimationsModule } from '@angular/platform-browser/animations';
+import { MaterialComponentsModule } from 'app/modules/material-components/material-components.module';
+import { RaidenIconsModule } from 'app/modules/raiden-icons/raiden-icons.module';
+import { DecimalPipe } from 'app/pipes/decimal.pipe';
+import { DisplayDecimalsPipe } from 'app/pipes/display-decimals.pipe';
+import { RaidenConfig } from 'app/services/raiden.config';
+import { ClipboardModule } from 'ngx-clipboard';
+import { MockConfig } from 'testing/mock-config';
+import { stub } from 'testing/stub';
+import {
+    createAddress,
+    createNetworkMock,
+    createToken,
+} from 'testing/test-data';
+import { TestProviders } from 'testing/test-providers';
+import Web3 from 'web3';
+import { BalanceWithSymbolComponent } from '../balance-with-symbol/balance-with-symbol.component';
+import { RaidenDialogComponent } from '../raiden-dialog/raiden-dialog.component';
+import { TokenInputComponent } from '../token-input/token-input.component';
+import { TokenNetworkSelectorComponent } from '../token-network-selector/token-network-selector.component';
+import {
+    AccountDialogComponent,
+    AccountDialogPayload,
+} from './account-dialog.component';
+import { Web3Factory } from 'app/services/web3-factory.service';
+import { By } from '@angular/platform-browser';
+import { RaidenService } from 'app/services/raiden.service';
+import { of } from 'rxjs';
+import {
+    clickElement,
+    mockInput,
+    mockMatSelectByIndex,
+    mockOpenMatSelect,
+} from 'testing/interaction-helper';
+import { TokenPollingService } from 'app/services/token-polling.service';
+import { UserDepositService } from 'app/services/user-deposit.service';
+import { NotificationService } from 'app/services/notification.service';
 
 describe('AccountDialogComponent', () => {
     let component: AccountDialogComponent;
     let fixture: ComponentFixture<AccountDialogComponent>;
 
+    const raidenAddress = createAddress();
+    const account = createAddress();
+    const chainId = 9100;
+    const token = createToken();
+    const servicesToken = createToken();
+
+    let web3Mock: Web3;
+
     beforeEach(async () => {
+        const payload: AccountDialogPayload = {
+            asset: 'ETH',
+        };
+
+        web3Mock = stub<Web3>();
+        web3Mock.eth = {
+            getAccounts: () => Promise.resolve([]),
+            requestAccounts: () => Promise.resolve([account]),
+            getChainId: () => Promise.resolve(chainId),
+            sendTransaction: () => Promise.resolve({}) as any,
+            // @ts-ignore
+            Contract: () => ({
+                methods: {
+                    transfer: () => ({
+                        send: () => {},
+                    }),
+                },
+            }),
+        };
+
+        const web3FactoryMock = stub<Web3Factory>();
+        web3FactoryMock.create = () => web3Mock;
+        web3FactoryMock.detectProvider = () =>
+            Promise.resolve('http://localhost:8545');
+
         await TestBed.configureTestingModule({
-            declarations: [AccountDialogComponent],
+            declarations: [
+                AccountDialogComponent,
+                TokenInputComponent,
+                TokenNetworkSelectorComponent,
+                RaidenDialogComponent,
+                BalanceWithSymbolComponent,
+                DisplayDecimalsPipe,
+                DecimalPipe,
+            ],
+            providers: [
+                TestProviders.MockMatDialogData(payload),
+                TestProviders.MockMatDialogRef(),
+                TestProviders.MockRaidenConfigProvider(),
+                TestProviders.AddressBookStubProvider(),
+                {
+                    provide: Web3Factory,
+                    useValue: web3FactoryMock,
+                },
+                TokenPollingService,
+                UserDepositService,
+                TestProviders.SpyNotificationServiceProvider(),
+            ],
+            imports: [
+                MaterialComponentsModule,
+                NoopAnimationsModule,
+                ReactiveFormsModule,
+                HttpClientTestingModule,
+                RaidenIconsModule,
+                ClipboardModule,
+            ],
         }).compileComponents();
     });
 
     beforeEach(() => {
+        const raidenConfig = TestBed.inject(RaidenConfig) as MockConfig;
+        raidenConfig.updateNetwork(createNetworkMock({ chainId }));
+
+        const raidenService = TestBed.inject(RaidenService);
+        spyOnProperty(raidenService, 'raidenAddress', 'get').and.returnValue(
+            raidenAddress
+        );
+        // @ts-ignore
+        raidenService.raidenAddress$ = of(raidenAddress);
+
+        const tokenPollingService = TestBed.inject(TokenPollingService);
+        spyOn(tokenPollingService, 'getTokenUpdates').and.returnValue(
+            of(token)
+        );
+        // @ts-ignore
+        tokenPollingService.tokens$ = of([token]);
+
+        const userDepositService = TestBed.inject(UserDepositService);
+        // @ts-ignore
+        userDepositService.servicesToken$ = of(servicesToken);
+
         fixture = TestBed.createComponent(AccountDialogComponent);
         component = fixture.componentInstance;
-        fixture.detectChanges();
     });
 
     it('should create', () => {
+        fixture.detectChanges();
         expect(component).toBeTruthy();
     });
 
-    // it('should have a faucet button when network has a faucet', () => {
-    //     expect(
-    //         fixture.debugElement.query(By.css('#faucet-button'))
-    //     ).toBeTruthy();
-    // });
+    it('should close the dialog with no result when close button is clicked', () => {
+        // @ts-ignore
+        const closeSpy = spyOn(component.dialogRef, 'close');
+        clickElement(fixture.debugElement, '#close');
+        fixture.detectChanges();
 
-    // it('should not have a faucet button when network does not have a faucet', () => {
-    //     networkSubject.next(createNetworkMock({ faucet: null }));
-    //     fixture.detectChanges();
-    //     expect(
-    //         fixture.debugElement.query(By.css('#faucet-button'))
-    //     ).toBeFalsy();
-    // });
+        expect(closeSpy).toHaveBeenCalledTimes(1);
+        expect(closeSpy).toHaveBeenCalledWith();
+    });
 
-    // it('should insert the address correctly into the href attribute of the faucet button', () => {
-    //     const href = fixture.debugElement
-    //         .query(By.css('#faucet-button'))
-    //         .nativeElement.getAttribute('href');
-    //     expect(href).toBe(`http://faucet.test/?${raidenAddress}`);
-    // });
+    it('should get the default account if already connected', fakeAsync(() => {
+        spyOn(web3Mock.eth, 'getAccounts').and.resolveTo([account]);
+        fixture.detectChanges();
+        tick();
+        expect(component.defaultAccount).toBe(account);
+        fixture.destroy();
+    }));
+
+    it('should connect to a wallet', fakeAsync(() => {
+        fixture.detectChanges();
+        tick();
+        fixture.detectChanges();
+        clickElement(fixture.debugElement, '#accept');
+        fixture.detectChanges();
+        tick();
+        expect(component.defaultAccount).toBe(account);
+        fixture.destroy();
+    }));
+
+    it('should show an error when the web3 provider uses a different chain', fakeAsync(() => {
+        fixture.detectChanges();
+        tick();
+        fixture.detectChanges();
+        spyOn(web3Mock.eth, 'getChainId').and.resolveTo(chainId + 1);
+        clickElement(fixture.debugElement, '#accept');
+        fixture.detectChanges();
+        tick();
+        expect(component.defaultAccount).toBe(undefined);
+        expect(component.wrongChainID).toBe(true);
+        fixture.destroy();
+    }));
+
+    it('should show an error when the user rejects account access', fakeAsync(() => {
+        fixture.detectChanges();
+        tick();
+        fixture.detectChanges();
+        spyOn(web3Mock.eth, 'requestAccounts').and.rejectWith();
+        clickElement(fixture.debugElement, '#accept');
+        fixture.detectChanges();
+        tick();
+        expect(component.defaultAccount).toBe(undefined);
+        expect(component.accountRequestRejected).toBe(true);
+        fixture.destroy();
+    }));
+
+    it('should send ETH to the Raiden account', fakeAsync(() => {
+        const notificationService = TestBed.inject(NotificationService);
+        const transactionSpy = spyOn(
+            web3Mock.eth,
+            'sendTransaction'
+        ).and.callThrough();
+        // @ts-ignore
+        const closeSpy = spyOn(component.dialogRef, 'close');
+        component.defaultAccount = account;
+        fixture.detectChanges();
+
+        mockInput(
+            fixture.debugElement.query(By.directive(TokenInputComponent)),
+            'input',
+            '0.5'
+        );
+        tick();
+        fixture.detectChanges();
+
+        clickElement(fixture.debugElement, '#accept');
+        fixture.detectChanges();
+        tick();
+
+        expect(closeSpy).toHaveBeenCalledTimes(1);
+        expect(closeSpy).toHaveBeenCalledWith();
+        expect(transactionSpy).toHaveBeenCalledTimes(1);
+        expect(transactionSpy).toHaveBeenCalledWith({
+            from: account,
+            to: raidenAddress,
+            value: '500000000000000000',
+        });
+        expect(notificationService.addPendingAction).toHaveBeenCalledTimes(1);
+        expect(notificationService.removePendingAction).toHaveBeenCalledTimes(
+            1
+        );
+        expect(
+            notificationService.addSuccessNotification
+        ).toHaveBeenCalledTimes(1);
+        fixture.destroy();
+    }));
+
+    it('should send tokens to the Raiden account', fakeAsync(() => {
+        const notificationService = TestBed.inject(NotificationService);
+        const sendSpy = jasmine.createSpy().and.resolveTo();
+        const contract = {
+            methods: {
+                transfer: (to, value) => ({
+                    send: sendSpy,
+                }),
+            },
+        };
+        const transferSpy = spyOn(
+            contract.methods,
+            'transfer'
+        ).and.callThrough();
+        // @ts-ignore
+        spyOn(web3Mock.eth, 'Contract').and.returnValue(contract);
+        // @ts-ignore
+        const closeSpy = spyOn(component.dialogRef, 'close');
+        component.defaultAccount = account;
+        fixture.detectChanges();
+
+        mockInput(
+            fixture.debugElement.query(By.directive(TokenInputComponent)),
+            'input',
+            '0.5'
+        );
+        tick();
+        fixture.detectChanges();
+
+        mockOpenMatSelect(fixture.debugElement);
+        fixture.detectChanges();
+        mockMatSelectByIndex(fixture.debugElement, 1);
+        fixture.detectChanges();
+
+        clickElement(fixture.debugElement, '#accept');
+        fixture.detectChanges();
+        tick();
+
+        expect(closeSpy).toHaveBeenCalledTimes(1);
+        expect(closeSpy).toHaveBeenCalledWith();
+        expect(transferSpy).toHaveBeenCalledTimes(1);
+        expect(transferSpy).toHaveBeenCalledWith(
+            raidenAddress,
+            '500000000000000000'
+        );
+        expect(sendSpy).toHaveBeenCalledTimes(1);
+        expect(sendSpy).toHaveBeenCalledWith({ from: account });
+        expect(notificationService.addPendingAction).toHaveBeenCalledTimes(1);
+        expect(notificationService.removePendingAction).toHaveBeenCalledTimes(
+            1
+        );
+        expect(
+            notificationService.addSuccessNotification
+        ).toHaveBeenCalledTimes(1);
+        flush();
+        fixture.destroy();
+    }));
+
+    it('should show an error if sending fails', fakeAsync(() => {
+        const notificationService = TestBed.inject(NotificationService);
+        spyOn(web3Mock.eth, 'sendTransaction').and.rejectWith(
+            Error('Tx failed.')
+        );
+        component.defaultAccount = account;
+        fixture.detectChanges();
+
+        mockInput(
+            fixture.debugElement.query(By.directive(TokenInputComponent)),
+            'input',
+            '0.5'
+        );
+        tick();
+        fixture.detectChanges();
+
+        clickElement(fixture.debugElement, '#accept');
+        fixture.detectChanges();
+        tick();
+
+        expect(notificationService.addPendingAction).toHaveBeenCalledTimes(1);
+        expect(notificationService.removePendingAction).toHaveBeenCalledTimes(
+            1
+        );
+        expect(notificationService.addErrorNotification).toHaveBeenCalledTimes(
+            1
+        );
+        fixture.destroy();
+    }));
+
+    it('should have a faucet button when network has a faucet', () => {
+        fixture.detectChanges();
+        expect(
+            fixture.debugElement.query(By.css('#faucet-button'))
+        ).toBeTruthy();
+    });
+
+    it('should not have a faucet button when network does not have a faucet', () => {
+        const raidenConfig = TestBed.inject(RaidenConfig) as MockConfig;
+        raidenConfig.updateNetwork(createNetworkMock({ faucet: null }));
+        fixture.detectChanges();
+        expect(
+            fixture.debugElement.query(By.css('#faucet-button'))
+        ).toBeFalsy();
+    });
+
+    it('should insert the address correctly into the href attribute of the faucet button', () => {
+        fixture.detectChanges();
+        const href = fixture.debugElement
+            .query(By.css('#faucet-button'))
+            .nativeElement.getAttribute('href');
+        expect(href).toBe(`http://faucet.test/?${raidenAddress}`);
+    });
 });

--- a/src/app/components/account-dialog/account-dialog.component.spec.ts
+++ b/src/app/components/account-dialog/account-dialog.component.spec.ts
@@ -194,7 +194,9 @@ describe('AccountDialogComponent', () => {
         fixture.detectChanges();
         tick();
         fixture.detectChanges();
-        spyOn(web3Mock.eth, 'requestAccounts').and.rejectWith();
+        spyOn(web3Mock.eth, 'requestAccounts').and.rejectWith(
+            new Error('User rejected.')
+        );
         clickElement(fixture.debugElement, '#accept');
         fixture.detectChanges();
         tick();

--- a/src/app/components/account-dialog/account-dialog.component.ts
+++ b/src/app/components/account-dialog/account-dialog.component.ts
@@ -1,0 +1,117 @@
+import { Inject, OnDestroy, ViewChild } from '@angular/core';
+import { Component, OnInit } from '@angular/core';
+import { FormGroup, FormBuilder, Validators } from '@angular/forms';
+import { MatDialogRef, MAT_DIALOG_DATA } from '@angular/material/dialog';
+import { UserToken } from 'app/models/usertoken';
+import { RaidenService } from 'app/services/raiden.service';
+import { TokenPollingService } from 'app/services/token-polling.service';
+import { UserDepositService } from 'app/services/user-deposit.service';
+import { Network } from 'app/utils/network-info';
+import BigNumber from 'bignumber.js';
+import { combineLatest, Observable, Subject, zip } from 'rxjs';
+import {
+    filter,
+    first,
+    map,
+    switchMap,
+    takeUntil,
+} from 'rxjs/operators';
+import { TokenInputComponent } from '../token-input/token-input.component';
+
+export interface AccountDialogPayload {
+    readonly asset: UserToken | 'ETH';
+}
+
+@Component({
+    selector: 'app-account-dialog',
+    templateUrl: './account-dialog.component.html',
+    styleUrls: ['./account-dialog.component.scss'],
+})
+export class AccountDialogComponent implements OnInit, OnDestroy {
+    @ViewChild(TokenInputComponent, { static: true })
+    private tokenInput: TokenInputComponent;
+
+    form: FormGroup;
+    token: UserToken;
+    balance: BigNumber;
+    ethSelected: boolean;
+
+    readonly network$: Observable<Network>;
+    readonly faucetLink$: Observable<string>;
+    readonly ethBalance$: Observable<string>;
+    readonly zeroEthBalance$: Observable<boolean>;
+
+    private ngUnsubscribe = new Subject();
+
+    constructor(
+        @Inject(MAT_DIALOG_DATA) data: AccountDialogPayload,
+        private dialogRef: MatDialogRef<AccountDialogComponent>,
+        private raidenService: RaidenService,
+        private fb: FormBuilder,
+        private tokenPollingService: TokenPollingService,
+        private userDepositService: UserDepositService
+    ) {
+        this.form = this.fb.group({
+            asset: [data.asset, Validators.required],
+            amount: ['', Validators.required],
+        });
+
+        this.ethBalance$ = raidenService.balance$;
+        this.zeroEthBalance$ = raidenService.balance$.pipe(
+            map((balance) => new BigNumber(balance).isZero())
+        );
+        this.network$ = raidenService.network$;
+        this.faucetLink$ = zip(
+            raidenService.network$,
+            raidenService.raidenAddress$
+        ).pipe(
+            map(([network, raidenAddress]) =>
+                network.faucet.replace('${ADDRESS}', raidenAddress)
+            )
+        );
+    }
+
+    ngOnInit(): void {
+        const servicesToken$ = this.userDepositService.servicesToken$.pipe(
+            first()
+        );
+        combineLatest([this.form.controls.asset.valueChanges, servicesToken$])
+            .pipe(
+                filter(([asset, servicesToken]) => asset !== 'ETH'),
+                switchMap(([selectedToken, servicesToken]) => {
+                    if (selectedToken.address === servicesToken.address) {
+                        return this.userDepositService.servicesToken$;
+                    }
+                    return this.tokenPollingService.getTokenUpdates(
+                        selectedToken.address
+                    );
+                }),
+                map((token) => token.balance),
+                takeUntil(this.ngUnsubscribe)
+            )
+            .subscribe((balance) => (this.balance = balance));
+
+        this.form.controls.asset.valueChanges
+            .pipe(takeUntil(this.ngUnsubscribe))
+            .subscribe((asset: UserToken | 'ETH') => {
+                this.tokenInput.selectedToken = asset;
+                if (asset === 'ETH') {
+                    this.ethSelected = true;
+                    this.token = undefined;
+                } else {
+                    this.ethSelected = false;
+                    this.token = asset;
+                }
+            });
+        this.form.controls.asset.updateValueAndValidity();
+    }
+
+    ngOnDestroy() {
+        this.ngUnsubscribe.next();
+        this.ngUnsubscribe.complete();
+    }
+
+    close() {
+        this.dialogRef.close();
+    }
+}

--- a/src/app/components/channel-list/channel-list.component.html
+++ b/src/app/components/channel-list/channel-list.component.html
@@ -29,6 +29,7 @@
                 [value]="selectedToken"
                 [showChannelBalance]="true"
                 [setSelectedToken]="true"
+                triggerText="Change Network"
                 placeholder="Select Network"
                 selectorClass="mat-select--dark"
                 panelClass="mat-select-panel--dark"

--- a/src/app/components/header/header.component.html
+++ b/src/app/components/header/header.component.html
@@ -20,14 +20,12 @@
         fxLayoutAlign="space-between start"
         fxLayoutGap="16px"
         fxFlex.gt-md="555 0 0"
-        fxLayout.xs="column"
-        fxLayoutGap.xs="30px"
     >
         <div
-            class="header__box"
+            class="header__box header__box--unpadded"
             fxLayout="row"
-            fxLayoutAlign="start center"
-            fxLayoutGap="16px"
+            fxLayoutAlign="space-evenly center"
+            fxFlex="1 0 0"
         >
             <div
                 *ngIf="balance$ | async as balance"
@@ -151,6 +149,7 @@
                         appStopClickPropagation
                         cdkOverlayOrigin
                         #tokenBalancesTrigger="cdkOverlayOrigin"
+                        id="on-chain-balances-button"
                     >
                         <mat-icon
                             class="balances-button__icon"
@@ -186,31 +185,19 @@
                     </ng-template>
                 </ng-container>
             </ng-container>
-        </div>
-
-        <div
-            fxLayout="row"
-            fxLayoutGap="4px"
-            fxLayoutAlign="start center"
-            class="header__box"
-            fxFlex.gt-md="1 0 0"
-        >
-            <mat-icon
-                svgIcon="user"
-                aria-hidden="true"
-                class="header__user-icon"
-            ></mat-icon>
-            <span
-                class="header__address"
-                matTooltip="Your account
-                {{ raidenAddress }}
-            (Click to copy)"
-                ngxClipboard
-                [cbContent]="raidenAddress"
-                fxFlex="1 0 0"
+            <div class="divider"></div>
+            <button
+                mat-icon-button
+                class="balances-button"
+                matTooltip="Fill up your account"
             >
-                {{ raidenAddress }}
-            </span>
+                <mat-icon
+                    class="balances-button__icon"
+                    svgIcon="deposit"
+                    aria-label="Fill up your account"
+                >
+                </mat-icon>
+            </button>
         </div>
     </div>
 
@@ -220,42 +207,52 @@
         fxLayoutGap="16px"
         fxFlex.gt-md="334 0 0"
     >
-        <a
-            *ngIf="(network$ | async)?.faucet"
-            [href]="faucetLink$ | async"
-            target="_blank"
-            mat-icon-button
-            class="account-button"
-            matTooltip="Open ether faucet"
-            fxLayout="column"
-            fxLayoutAlign="center center"
-            fxFlexAlign="center"
-            id="faucet-button"
+        <div
+            fxLayout="row"
+            fxLayoutAlign="start center"
+            class="header__box"
         >
-            <mat-icon
-                class="account-button__icon-faucet"
-                svgIcon="faucet"
-                aria-label="Open ether faucet"
-            >
-            </mat-icon>
-        </a>
-        <button
-            mat-icon-button
-            matTooltip="Show QR code to scan your address"
-            (click)="showOwnAddressQrCode()"
-            class="account-button"
-            fxLayout="column"
-            fxLayoutAlign="center center"
-            fxFlexAlign="center"
-            id="qr-button"
-        >
-            <mat-icon
-                class="account-button__icon-qr"
-                svgIcon="qr"
-                aria-label="Show QR code to scan your address"
-            >
-            </mat-icon>
-        </button>
+            <div fxLayout="column" fxLayoutGap="4px">
+                <span fxLayout="row" fxLayoutGap="6px">
+                    <mat-icon
+                        svgIcon="user"
+                        aria-hidden="true"
+                        class="header__user-icon"
+                        matTooltip="Your account
+                            {{ raidenAddress }}
+                            (Click to copy)"
+                        ngxClipboard
+                        [cbContent]="raidenAddress"
+                    ></mat-icon>
+                    <button
+                        mat-icon-button
+                        matTooltip="Show QR code to scan your address"
+                        (click)="showOwnAddressQrCode()"
+                        class="small-balance-button"
+                        fxLayout="column"
+                        fxLayoutAlign="center center"
+                        id="qr-button"
+                    >
+                        <mat-icon
+                            class="small-balance-button__icon small-balance-button__icon--small"
+                            svgIcon="qr"
+                            aria-label="Show QR code to scan your address"
+                        >
+                        </mat-icon>
+                    </button>
+                </span>
+                <span
+                    class="header__address"
+                    matTooltip="Your account
+                        {{ raidenAddress }}
+                        (Click to copy)"
+                    ngxClipboard
+                    [cbContent]="raidenAddress"
+                >
+                    {{ raidenAddress | shortenAddress }}
+                </span>
+            </div>
+        </div>
         <app-search-field
             fxFlex="1 0 0"
             fxFlex.lt-lg="0 1 233px"

--- a/src/app/components/header/header.component.html
+++ b/src/app/components/header/header.component.html
@@ -40,23 +40,26 @@
                         {{ balance | displayDecimals: 3 }}&nbsp;
                     </span>
                     <span class="header__balance header__balance--uppercase">
-                        {{ (network$ | async)?.shortName }}
+                        ETH
                     </span>
-                    <span
+                    <button
                         *ngIf="zeroBalance$ | async"
-                        class="alert"
+                        class="small-balance-button small-balance-button--alert"
+                        mat-icon-button
+                        matTooltip="Funds needed"
                         fxLayout="column"
                         fxLayoutAlign="center center"
                         fxFlexOffset="6px"
+                        (click)="openAccountDialog('ETH')"
+                        id="balance-alert"
                     >
                         <mat-icon
+                            class="small-balance-button__icon"
                             svgIcon="down-arrow"
-                            aria-hidden="true"
-                            class="alert__icon"
-                            matTooltip="Funds needed"
-                            id="balance-alert"
-                        ></mat-icon>
-                    </span>
+                            aria-label="Funds needed"
+                        >
+                        </mat-icon>
+                    </button>
                 </span>
                 <span class="header__label">On-Chain</span>
             </div>
@@ -189,12 +192,13 @@
             <button
                 mat-icon-button
                 class="balances-button"
-                matTooltip="Fill up your account"
+                matTooltip="Top up your account"
+                (click)="openAccountDialog(selectedToken ?? 'ETH')"
             >
                 <mat-icon
                     class="balances-button__icon"
                     svgIcon="deposit"
-                    aria-label="Fill up your account"
+                    aria-label="Top up your account"
                 >
                 </mat-icon>
             </button>
@@ -207,11 +211,7 @@
         fxLayoutGap="16px"
         fxFlex.gt-md="334 0 0"
     >
-        <div
-            fxLayout="row"
-            fxLayoutAlign="start center"
-            class="header__box"
-        >
+        <div fxLayout="row" fxLayoutAlign="start center" class="header__box">
             <div fxLayout="column" fxLayoutGap="4px">
                 <span fxLayout="row" fxLayoutGap="6px">
                     <mat-icon
@@ -234,7 +234,10 @@
                         id="qr-button"
                     >
                         <mat-icon
-                            class="small-balance-button__icon small-balance-button__icon--small"
+                            class="
+                                small-balance-button__icon
+                                small-balance-button__icon--small
+                            "
                             svgIcon="qr"
                             aria-label="Show QR code to scan your address"
                         >

--- a/src/app/components/header/header.component.html
+++ b/src/app/components/header/header.component.html
@@ -194,6 +194,7 @@
                 class="balances-button"
                 matTooltip="Top up your account"
                 (click)="openAccountDialog(selectedToken ?? 'ETH')"
+                id="open-account"
             >
                 <mat-icon
                     class="balances-button__icon"

--- a/src/app/components/header/header.component.scss
+++ b/src/app/components/header/header.component.scss
@@ -35,17 +35,17 @@
         background-color: $bg-dark-grey;
         padding: 0 16px;
         border-radius: 15px;
+
+        &--unpadded {
+            padding: 0;
+        }
     }
 
     &__address {
-        width: 60px;
         color: $light-grey;
         font-size: 12px;
         line-height: 14px;
         letter-spacing: 1.07px;
-        white-space: nowrap;
-        overflow: hidden;
-        text-overflow: ellipsis;
     }
 
     &__user-icon {
@@ -85,6 +85,12 @@
         height: 16px !important;
         width: 16px !important;
         line-height: 16px;
+
+        &--small {
+            width: 13px !important;
+            height: 13px !important;
+            line-height: 13px !important;
+        }
     }
 
     &--alert {
@@ -159,22 +165,6 @@
             border-bottom: none;
             padding-bottom: 12px;
         }
-    }
-}
-
-.account-button {
-    height: 29px !important;
-    width: 29px !important;
-    border: 2px solid $white;
-
-    &__icon-faucet {
-        height: 15px !important;
-        line-height: 15px !important;
-    }
-
-    &__icon-qr {
-        height: 13px !important;
-        line-height: 13px !important;
     }
 }
 

--- a/src/app/components/header/header.component.scss
+++ b/src/app/components/header/header.component.scss
@@ -54,20 +54,6 @@
     }
 }
 
-.alert {
-    background-color: $bg-label-red;
-    width: 24px;
-    height: 24px;
-    border-radius: 50%;
-    color: $label-red;
-    margin: -4px 0;
-
-    &__icon {
-        height: 16px;
-        width: 16px;
-    }
-}
-
 .divider {
     height: 36px;
     width: 1px;

--- a/src/app/components/header/header.component.spec.ts
+++ b/src/app/components/header/header.component.spec.ts
@@ -41,6 +41,7 @@ import { BalanceWithSymbolComponent } from '../balance-with-symbol/balance-with-
 import { SelectedTokenService } from 'app/services/selected-token.service';
 import { getMintAmount } from 'app/shared/mint-amount';
 import { UserDepositDialogComponent } from '../user-deposit-dialog/user-deposit-dialog.component';
+import { ShortenAddressPipe } from 'app/pipes/shorten-address.pipe';
 
 describe('HeaderComponent', () => {
     let component: HeaderComponent;
@@ -86,6 +87,7 @@ describe('HeaderComponent', () => {
                     SearchFieldComponent,
                     DecimalPipe,
                     BalanceWithSymbolComponent,
+                    ShortenAddressPipe,
                 ],
                 providers: [
                     NotificationService,
@@ -127,27 +129,6 @@ describe('HeaderComponent', () => {
     it('should create', () => {
         expect(component).toBeTruthy();
         fixture.destroy();
-    });
-
-    it('should have a faucet button when network has a faucet', () => {
-        expect(
-            fixture.debugElement.query(By.css('#faucet-button'))
-        ).toBeTruthy();
-    });
-
-    it('should not have a faucet button when network does not have a faucet', () => {
-        networkSubject.next(createNetworkMock({ faucet: null }));
-        fixture.detectChanges();
-        expect(
-            fixture.debugElement.query(By.css('#faucet-button'))
-        ).toBeFalsy();
-    });
-
-    it('should insert the address correctly into the href attribute of the faucet button', () => {
-        const href = fixture.debugElement
-            .query(By.css('#faucet-button'))
-            .nativeElement.getAttribute('href');
-        expect(href).toBe(`http://faucet.test/?${raidenAddress}`);
     });
 
     it('should show the qr code dialog for the raiden address', () => {
@@ -209,7 +190,7 @@ describe('HeaderComponent', () => {
         fixture.detectChanges();
 
         expect(
-            fixture.debugElement.query(By.css('.balances-button'))
+            fixture.debugElement.query(By.css('#on-chain-balances-button'))
         ).toBeFalsy();
         const balances = fixture.debugElement.queryAll(
             By.css('.header__token-balance')

--- a/src/app/components/header/header.component.spec.ts
+++ b/src/app/components/header/header.component.spec.ts
@@ -42,6 +42,7 @@ import { SelectedTokenService } from 'app/services/selected-token.service';
 import { getMintAmount } from 'app/shared/mint-amount';
 import { UserDepositDialogComponent } from '../user-deposit-dialog/user-deposit-dialog.component';
 import { ShortenAddressPipe } from 'app/pipes/shorten-address.pipe';
+import { AccountDialogComponent } from '../account-dialog/account-dialog.component';
 
 describe('HeaderComponent', () => {
     let component: HeaderComponent;
@@ -260,6 +261,37 @@ describe('HeaderComponent', () => {
         expect(dialogSpy).toHaveBeenCalledTimes(1);
         expect(dialogSpy).toHaveBeenCalledWith(UserDepositDialogComponent, {
             width: '509px',
+        });
+    });
+
+    it('should open the account dialog with the selected token', () => {
+        const dialog = TestBed.inject(MatDialog) as unknown as MockMatDialog;
+        const dialogSpy = spyOn(dialog, 'open');
+        const selectedTokenService = TestBed.inject(SelectedTokenService);
+        selectedTokenService.setToken(tokens[2]);
+        fixture.detectChanges();
+
+        clickElement(fixture.debugElement, '#open-account');
+        fixture.detectChanges();
+
+        expect(dialogSpy).toHaveBeenCalledTimes(1);
+        expect(dialogSpy).toHaveBeenCalledWith(AccountDialogComponent, {
+            data: { asset: tokens[2] },
+        });
+    });
+
+    it('should open the account dialog with ETH', () => {
+        const dialog = TestBed.inject(MatDialog) as unknown as MockMatDialog;
+        const dialogSpy = spyOn(dialog, 'open');
+        balanceSubject.next('0');
+        fixture.detectChanges();
+
+        clickElement(fixture.debugElement, '#balance-alert');
+        fixture.detectChanges();
+
+        expect(dialogSpy).toHaveBeenCalledTimes(1);
+        expect(dialogSpy).toHaveBeenCalledWith(AccountDialogComponent, {
+            data: { asset: 'ETH' },
         });
     });
 });

--- a/src/app/components/header/header.component.ts
+++ b/src/app/components/header/header.component.ts
@@ -42,7 +42,6 @@ export class HeaderComponent implements OnInit, OnDestroy {
     readonly network$: Observable<Network>;
     readonly balance$: Observable<string>;
     readonly zeroBalance$: Observable<boolean>;
-    readonly faucetLink$: Observable<string>;
     readonly numberOfNotifications$: Observable<number>;
     readonly udcBalance$: Observable<BigNumber>;
     readonly servicesToken$: Observable<UserToken>;
@@ -69,14 +68,6 @@ export class HeaderComponent implements OnInit, OnDestroy {
         this.balance$ = raidenService.balance$;
         this.zeroBalance$ = raidenService.balance$.pipe(
             map((balance) => new BigNumber(balance).isZero())
-        );
-        this.faucetLink$ = zip(
-            raidenService.network$,
-            raidenService.raidenAddress$
-        ).pipe(
-            map(([network, raidenAddress]) =>
-                network.faucet.replace('${ADDRESS}', raidenAddress)
-            )
         );
         this.numberOfNotifications$ =
             this.notificationService.numberOfNotifications$;

--- a/src/app/components/token-input/token-input.component.html
+++ b/src/app/components/token-input/token-input.component.html
@@ -18,7 +18,7 @@
         />
 
         <div class="input__symbol">
-            {{ selectedToken?.symbol }}
+            {{ ethInput ? 'ETH' : selectedToken?.symbol }}
         </div>
     </div>
 
@@ -52,8 +52,8 @@
         <span *ngIf="errors['negativeAmount']">
             The amount should not be negative
         </span>
-        <span *ngIf="errors['tooManyDecimals'] && selectedToken">
-            The selected token network only supports up to
+        <span *ngIf="errors['tooManyDecimals'] && (selectedToken || ethInput)">
+            {{ ethInput ? 'Ether' : 'The selected token' }} only supports up to
             {{ decimals }} decimals
         </span>
         <span *ngIf="errors['notANumber']">

--- a/src/app/components/token-input/token-input.component.spec.ts
+++ b/src/app/components/token-input/token-input.component.spec.ts
@@ -135,6 +135,15 @@ describe('TokenInputComponent', () => {
         expect(component.errors['tooManyDecimals']).toBe(true);
     });
 
+    it('should use 18 decimals when used as ETH input', () => {
+        component.selectedToken = 'ETH';
+        mockInput(fixture.debugElement, 'input', '0.000000000000000010');
+        fixture.detectChanges();
+        expect(component.decimals).toBe(18);
+        expect(component.amount.isEqualTo(10)).toBe(true);
+        expect(component.errors).toBeFalsy();
+    });
+
     it('should be able to set a string value programmatically', () => {
         component.writeValue('0.00003');
         fixture.detectChanges();

--- a/src/app/components/token-input/token-input.component.ts
+++ b/src/app/components/token-input/token-input.component.ts
@@ -52,6 +52,7 @@ export class TokenInputComponent implements ControlValueAccessor, Validator {
     errors: ValidationErrors = { empty: true };
     touched = false;
     disabled = false;
+    ethInput = false;
 
     private _selectedToken: UserToken;
     private _maxAmount: BigNumber;
@@ -59,15 +60,30 @@ export class TokenInputComponent implements ControlValueAccessor, Validator {
     constructor() {}
 
     get decimals(): number {
-        return this._selectedToken ? this._selectedToken.decimals : 0;
+        let decimals: number;
+        if (this.ethInput) {
+            decimals = 18;
+        } else if (this._selectedToken) {
+            decimals = this._selectedToken.decimals;
+        } else {
+            decimals = 0;
+        }
+        return decimals;
     }
 
     get selectedToken(): UserToken {
         return this._selectedToken;
     }
 
-    set selectedToken(value: UserToken) {
-        this._selectedToken = value;
+    set selectedToken(value: UserToken | 'ETH') {
+        if (value === 'ETH') {
+            this._selectedToken = undefined;
+            this.ethInput = true;
+        } else {
+            this._selectedToken = value;
+            this.ethInput = false;
+        }
+
         if (BigNumber.isBigNumber(this.amount) && !this.amount.isNaN()) {
             const newDecimalAmount = amountToDecimal(
                 this.amount,

--- a/src/app/components/token-input/token-input.component.ts
+++ b/src/app/components/token-input/token-input.component.ts
@@ -60,15 +60,12 @@ export class TokenInputComponent implements ControlValueAccessor, Validator {
     constructor() {}
 
     get decimals(): number {
-        let decimals: number;
         if (this.ethInput) {
-            decimals = 18;
+            return 18;
         } else if (this._selectedToken) {
-            decimals = this._selectedToken.decimals;
-        } else {
-            decimals = 0;
+            return this._selectedToken.decimals;
         }
-        return decimals;
+        return 0;
     }
 
     get selectedToken(): UserToken {

--- a/src/app/components/token-network-selector/token-network-selector.component.html
+++ b/src/app/components/token-network-selector/token-network-selector.component.html
@@ -9,9 +9,14 @@
     #selector
 >
     <mat-select-trigger>
-        <ng-container *ngIf="setSelectedToken; else token_info">
-            Change Network
+        <ng-container *ngIf="triggerText; else eth_info">
+            {{ triggerText }}
         </ng-container>
+        <ng-template #eth_info>
+            <ng-container *ngIf="value === 'ETH'; else token_info">
+                ETH
+            </ng-container>
+        </ng-template>
         <ng-template #token_info>
             <ng-container *ngIf="!!value">
                 {{ value.symbol }} {{ value.name }} {{ value.address }}
@@ -35,6 +40,9 @@
         <span>Add new Network</span>
     </button>
     <mat-option *ngIf="setSelectedToken">All Networks</mat-option>
+    <mat-option *ngIf="showEthOption" value="ETH">
+        {{ ethBalance$ | async | displayDecimals: 3 }} ETH
+    </mat-option>
     <mat-option
         *ngFor="let option of tokens$ | async; trackBy: trackByFn"
         [value]="option"

--- a/src/app/components/token-network-selector/token-network-selector.component.spec.ts
+++ b/src/app/components/token-network-selector/token-network-selector.component.spec.ts
@@ -20,6 +20,7 @@ import { MatDialog } from '@angular/material/dialog';
 import { MockMatDialog } from '../../../testing/mock-mat-dialog';
 import { RegisterDialogComponent } from '../register-dialog/register-dialog.component';
 import { RaidenIconsModule } from '../../modules/raiden-icons/raiden-icons.module';
+import { DisplayDecimalsPipe } from 'app/pipes/display-decimals.pipe';
 
 describe('TokenNetworkSelectorComponent', () => {
     let component: TokenNetworkSelectorComponent;
@@ -41,6 +42,10 @@ describe('TokenNetworkSelectorComponent', () => {
         balance: new BigNumber(0),
     });
     const tokens = [connectedToken, ownedToken, notOwnedToken];
+    const servicesToken = createToken({
+        symbol: 'STT',
+        name: 'Service Test Token',
+    });
 
     beforeEach(
         waitForAsync(() => {
@@ -50,7 +55,10 @@ describe('TokenNetworkSelectorComponent', () => {
             tokenPollingMock.refresh = () => {};
 
             TestBed.configureTestingModule({
-                declarations: [TokenNetworkSelectorComponent],
+                declarations: [
+                    TokenNetworkSelectorComponent,
+                    DisplayDecimalsPipe,
+                ],
                 providers: [
                     TestProviders.MockRaidenConfigProvider(),
                     {
@@ -60,6 +68,7 @@ describe('TokenNetworkSelectorComponent', () => {
                     RaidenService,
                     TestProviders.AddressBookStubProvider(),
                     TestProviders.MockMatDialog(),
+                    TestProviders.MockUserDepositService(servicesToken),
                 ],
                 imports: [
                     MaterialComponentsModule,
@@ -75,10 +84,10 @@ describe('TokenNetworkSelectorComponent', () => {
     beforeEach(() => {
         fixture = TestBed.createComponent(TokenNetworkSelectorComponent);
         component = fixture.componentInstance;
-        fixture.detectChanges();
     });
 
     it('should create', () => {
+        fixture.detectChanges();
         expect(component).toBeTruthy();
     });
 
@@ -108,16 +117,62 @@ describe('TokenNetworkSelectorComponent', () => {
         mockMatSelectFirst(fixture.debugElement);
         fixture.detectChanges();
 
-        expect(component.value).toBe(connectedToken);
+        expect(component.value).toEqual(connectedToken);
         expect(touchedSpy).toHaveBeenCalled();
         expect(changeSpy).toHaveBeenCalledTimes(1);
         expect(changeSpy).toHaveBeenCalledWith(connectedToken);
     });
 
+    it('should be able to show and select ETH', () => {
+        component.showEthOption = true;
+        const changeSpy = jasmine.createSpy('onChange');
+        const touchedSpy = jasmine.createSpy('onTouched');
+        component.registerOnChange(changeSpy);
+        component.registerOnTouched(touchedSpy);
+        fixture.detectChanges();
+
+        mockOpenMatSelect(fixture.debugElement);
+        fixture.detectChanges();
+
+        mockMatSelectFirst(fixture.debugElement);
+        fixture.detectChanges();
+
+        expect(component.value).toBe('ETH');
+        expect(touchedSpy).toHaveBeenCalled();
+        expect(changeSpy).toHaveBeenCalledTimes(1);
+        expect(changeSpy).toHaveBeenCalledWith('ETH');
+    });
+
+    it('should be able to show and select the services token', () => {
+        component.showServicesToken = true;
+        const changeSpy = jasmine.createSpy('onChange');
+        const touchedSpy = jasmine.createSpy('onTouched');
+        component.registerOnChange(changeSpy);
+        component.registerOnTouched(touchedSpy);
+        fixture.detectChanges();
+
+        mockOpenMatSelect(fixture.debugElement);
+        fixture.detectChanges();
+
+        mockMatSelectFirst(fixture.debugElement);
+        fixture.detectChanges();
+
+        expect(component.value).toEqual(servicesToken);
+        expect(touchedSpy).toHaveBeenCalled();
+        expect(changeSpy).toHaveBeenCalledTimes(1);
+        expect(changeSpy).toHaveBeenCalledWith(servicesToken);
+    });
+
     it('should be able to set a value programmatically', () => {
         component.writeValue(notOwnedToken);
         fixture.detectChanges();
-        expect(component.value).toBe(notOwnedToken);
+        expect(component.value).toEqual(notOwnedToken);
+    });
+
+    it('should be able to set ETH as value programmatically', () => {
+        component.writeValue('ETH');
+        fixture.detectChanges();
+        expect(component.value).toBe('ETH');
     });
 
     it('should not to set a non token object programmatically', () => {

--- a/src/app/components/token-network-selector/token-network-selector.component.ts
+++ b/src/app/components/token-network-selector/token-network-selector.component.ts
@@ -65,7 +65,15 @@ export class TokenNetworkSelectorComponent
                 this.tokens$,
                 this.userDepositService.servicesToken$,
             ]).pipe(
-                map(([tokens, servicesToken]) => [servicesToken, ...tokens])
+                map(([tokens, servicesToken]) => {
+                    const servicesTokenRegistered = !!tokens.find(
+                        (item) => servicesToken.address === item.address
+                    );
+                    if (servicesTokenRegistered) {
+                        return tokens;
+                    }
+                    return [servicesToken, ...tokens];
+                })
             );
         }
     }

--- a/src/app/components/token/token.component.html
+++ b/src/app/components/token/token.component.html
@@ -81,6 +81,7 @@
             [value]="selectedToken"
             [showChannelBalance]="true"
             [setSelectedToken]="true"
+            triggerText="Change Network"
             [showRegisterButton]="!production"
             placeholder="Select Network"
             selectorClass="mat-select--dark"

--- a/src/app/components/user-deposit-dialog/deposit-withdraw-form/deposit-withdraw-form.component.spec.ts
+++ b/src/app/components/user-deposit-dialog/deposit-withdraw-form/deposit-withdraw-form.component.spec.ts
@@ -23,7 +23,7 @@ import {
 import BigNumber from 'bignumber.js';
 import { ClipboardModule } from 'ngx-clipboard';
 import { BehaviorSubject } from 'rxjs';
-import { clickElement, mockInput } from 'testing/interaction-helper';
+import { mockInput } from 'testing/interaction-helper';
 import { MockMatDialog } from 'testing/mock-mat-dialog';
 import { createToken } from 'testing/test-data';
 import { TestProviders } from 'testing/test-providers';

--- a/src/app/components/user-deposit-dialog/deposit-withdraw-form/deposit-withdraw-form.component.ts
+++ b/src/app/components/user-deposit-dialog/deposit-withdraw-form/deposit-withdraw-form.component.ts
@@ -114,7 +114,6 @@ export class DepositWithdrawFormComponent implements OnInit, OnDestroy {
     }
 
     onEnter(event: Event) {
-        console.log(event);
         event.stopPropagation();
         if (this.form.invalid) {
             return;

--- a/src/app/pipes/shorten-address.pipe.spec.ts
+++ b/src/app/pipes/shorten-address.pipe.spec.ts
@@ -1,0 +1,29 @@
+import { ShortenAddressPipe } from './shorten-address.pipe';
+
+describe('ShortenAddressPipe', () => {
+    let pipe: ShortenAddressPipe;
+
+    beforeEach(() => {
+        pipe = new ShortenAddressPipe();
+    });
+
+    it('create an instance', () => {
+        expect(pipe).toBeTruthy();
+    });
+
+    it('should return the same value if it is smaller than', function() {
+        expect(pipe.transform('123')).toEqual('123');
+    });
+
+    it('should return the address truncated to 6 characters without touching the 0x prefix', function() {
+        expect(pipe.transform('0x0123456789012345678901234567890123456789')).toEqual('0x012...789');
+    });
+
+    it('should return the value truncated', function() {
+        expect(pipe.transform('12345678', 4)).toEqual('12...78');
+    });
+
+    it('should return an empty string if no value', function() {
+        expect(pipe.transform(undefined)).toEqual('');
+    });
+});

--- a/src/app/pipes/shorten-address.pipe.spec.ts
+++ b/src/app/pipes/shorten-address.pipe.spec.ts
@@ -11,19 +11,21 @@ describe('ShortenAddressPipe', () => {
         expect(pipe).toBeTruthy();
     });
 
-    it('should return the same value if it is smaller than', function() {
+    it('should return the same value if it is smaller than', function () {
         expect(pipe.transform('123')).toEqual('123');
     });
 
-    it('should return the address truncated to 6 characters without touching the 0x prefix', function() {
-        expect(pipe.transform('0x0123456789012345678901234567890123456789')).toEqual('0x012...789');
+    it('should return the address truncated to 6 characters without touching the 0x prefix', function () {
+        expect(
+            pipe.transform('0x0123456789012345678901234567890123456789')
+        ).toEqual('0x012...789');
     });
 
-    it('should return the value truncated', function() {
+    it('should return the value truncated', function () {
         expect(pipe.transform('12345678', 4)).toEqual('12...78');
     });
 
-    it('should return an empty string if no value', function() {
+    it('should return an empty string if no value', function () {
         expect(pipe.transform(undefined)).toEqual('');
     });
 });

--- a/src/app/pipes/shorten-address.pipe.spec.ts
+++ b/src/app/pipes/shorten-address.pipe.spec.ts
@@ -18,11 +18,11 @@ describe('ShortenAddressPipe', () => {
     it('should return the address truncated to 6 characters without touching the 0x prefix', function () {
         expect(
             pipe.transform('0x0123456789012345678901234567890123456789')
-        ).toEqual('0x012...789');
+        ).toEqual('0x012…789');
     });
 
     it('should return the value truncated', function () {
-        expect(pipe.transform('12345678', 4)).toEqual('12...78');
+        expect(pipe.transform('12345678', 4)).toEqual('12…78');
     });
 
     it('should return an empty string if no value', function () {

--- a/src/app/pipes/shorten-address.pipe.ts
+++ b/src/app/pipes/shorten-address.pipe.ts
@@ -1,0 +1,28 @@
+import { Pipe, PipeTransform } from '@angular/core';
+
+@Pipe({
+  name: 'shortenAddress'
+})
+export class ShortenAddressPipe implements PipeTransform {
+  transform(value?: string, width: number = 6): string {
+      const separator = '...';
+      if (!value) {
+          return '';
+      } else if (value.length <= width) {
+          return value;
+      } else {
+          let prefix = '';
+          if (value.startsWith('0x')) {
+            prefix = '0x';
+            value = value.substr(2);
+          }
+          const substWidth = Math.floor(width / 2);
+          return (
+              prefix +
+              value.substr(0, substWidth) +
+              separator +
+              value.substr(value.length - substWidth)
+          );
+      }
+  }
+}

--- a/src/app/pipes/shorten-address.pipe.ts
+++ b/src/app/pipes/shorten-address.pipe.ts
@@ -1,28 +1,28 @@
 import { Pipe, PipeTransform } from '@angular/core';
 
 @Pipe({
-  name: 'shortenAddress'
+    name: 'shortenAddress',
 })
 export class ShortenAddressPipe implements PipeTransform {
-  transform(value?: string, width: number = 6): string {
-      const separator = '...';
-      if (!value) {
-          return '';
-      } else if (value.length <= width) {
-          return value;
-      } else {
-          let prefix = '';
-          if (value.startsWith('0x')) {
-            prefix = '0x';
-            value = value.substr(2);
-          }
-          const substWidth = Math.floor(width / 2);
-          return (
-              prefix +
-              value.substr(0, substWidth) +
-              separator +
-              value.substr(value.length - substWidth)
-          );
-      }
-  }
+    transform(value?: string, width: number = 6): string {
+        const separator = '...';
+        if (!value) {
+            return '';
+        } else if (value.length <= width) {
+            return value;
+        } else {
+            let prefix = '';
+            if (value.startsWith('0x')) {
+                prefix = '0x';
+                value = value.substr(2);
+            }
+            const substWidth = Math.floor(width / 2);
+            return (
+                prefix +
+                value.substr(0, substWidth) +
+                separator +
+                value.substr(value.length - substWidth)
+            );
+        }
+    }
 }

--- a/src/app/pipes/shorten-address.pipe.ts
+++ b/src/app/pipes/shorten-address.pipe.ts
@@ -5,7 +5,7 @@ import { Pipe, PipeTransform } from '@angular/core';
 })
 export class ShortenAddressPipe implements PipeTransform {
     transform(value?: string, width: number = 6): string {
-        const separator = '...';
+        const separator = '…';
         if (!value) {
             return '';
         } else if (value.length <= width) {

--- a/src/app/services/raiden.config.spec.ts
+++ b/src/app/services/raiden.config.spec.ts
@@ -1,5 +1,5 @@
 import { fakeAsync, flush, inject, TestBed, tick } from '@angular/core/testing';
-import { RaidenConfig, Web3Factory } from './raiden.config';
+import { RaidenConfig } from './raiden.config';
 import { HttpClientModule } from '@angular/common/http';
 import {
     HttpClientTestingModule,
@@ -10,6 +10,7 @@ import { EnvironmentType } from '../models/enviroment-type.enum';
 import Web3 from 'web3';
 import { HttpProvider } from 'web3-core';
 import Spy = jasmine.Spy;
+import { Web3Factory } from './web3-factory.service';
 
 describe('RaidenConfig', () => {
     let testingController: HttpTestingController;
@@ -259,31 +260,5 @@ describe('RaidenConfig', () => {
             raidenConfig.config.web3_fallback
         );
         flush();
-    }));
-});
-
-describe('Web3Factory', () => {
-    let web3Factory: Web3Factory;
-
-    beforeEach(() => {
-        TestBed.configureTestingModule({
-            imports: [HttpClientTestingModule],
-            providers: [Web3Factory],
-        });
-
-        web3Factory = TestBed.inject(Web3Factory);
-    });
-
-    it('should be created', inject([Web3Factory], (service: Web3Factory) => {
-        expect(service).toBeTruthy();
-    }));
-
-    it('should create a new web3 instance', fakeAsync(() => {
-        const web3 = web3Factory.create(
-            new Web3.providers.HttpProvider('http://localhost:8485')
-        );
-        expect((web3.currentProvider as HttpProvider).host).toBe(
-            'http://localhost:8485'
-        );
     }));
 });

--- a/src/app/services/raiden.config.ts
+++ b/src/app/services/raiden.config.ts
@@ -1,11 +1,12 @@
 import { HttpClient, HttpBackend } from '@angular/common/http';
 import { Injectable } from '@angular/core';
 import { EnvironmentType } from '../models/enviroment-type.enum';
-import { HttpProvider, provider } from 'web3-core';
+import { HttpProvider } from 'web3-core';
 import Web3 from 'web3';
 import { Observable, ReplaySubject } from 'rxjs';
 import { Network, NetworkInfo } from '../utils/network-info';
 import { NotificationService } from './notification.service';
+import { Web3Factory } from './web3-factory.service';
 
 interface RDNConfig {
     raiden: string;
@@ -32,13 +33,6 @@ const default_config: RDNConfig = {
     reveal_timeout: 10,
     environment_type: EnvironmentType.DEVELOPMENT,
 };
-
-@Injectable()
-export class Web3Factory {
-    create(web3Provider: provider): Web3 {
-        return new Web3(web3Provider);
-    }
-}
 
 @Injectable()
 export class RaidenConfig {

--- a/src/app/services/raiden.service.spec.ts
+++ b/src/app/services/raiden.service.spec.ts
@@ -10,7 +10,7 @@ import {
 import { fakeAsync, flush, inject, TestBed, tick } from '@angular/core/testing';
 import { of } from 'rxjs';
 import { Channel } from '../models/channel';
-import { RaidenConfig, Web3Factory } from './raiden.config';
+import { RaidenConfig } from './raiden.config';
 import { RaidenService } from './raiden.service';
 import { TokenInfoRetrieverService } from './token-info-retriever.service';
 import { TestProviders } from '../../testing/test-providers';
@@ -39,6 +39,7 @@ import { PaymentEvent } from '../models/payment-event';
 import { MockConfig } from '../../testing/mock-config';
 import { TokenInfo } from '../models/usertoken';
 import { Settings } from '../models/settings';
+import { Web3Factory } from './web3-factory.service';
 
 describe('RaidenService', () => {
     const token = createToken();

--- a/src/app/services/web3-factory.service.spec.ts
+++ b/src/app/services/web3-factory.service.spec.ts
@@ -1,0 +1,31 @@
+import { HttpClientTestingModule } from '@angular/common/http/testing';
+import { TestBed, fakeAsync } from '@angular/core/testing';
+import Web3 from 'web3';
+import { Web3Factory } from './web3-factory.service';
+import { HttpProvider } from 'web3-core';
+
+describe('Web3Factory', () => {
+    let web3Factory: Web3Factory;
+
+    beforeEach(() => {
+        TestBed.configureTestingModule({
+            imports: [HttpClientTestingModule],
+            providers: [Web3Factory],
+        });
+
+        web3Factory = TestBed.inject(Web3Factory);
+    });
+
+    it('should be created', () => {
+        expect(web3Factory).toBeTruthy();
+    });
+
+    it('should create a new web3 instance', fakeAsync(() => {
+        const web3 = web3Factory.create(
+            new Web3.providers.HttpProvider('http://localhost:8485')
+        );
+        expect((web3.currentProvider as HttpProvider).host).toBe(
+            'http://localhost:8485'
+        );
+    }));
+});

--- a/src/app/services/web3-factory.service.ts
+++ b/src/app/services/web3-factory.service.ts
@@ -1,0 +1,16 @@
+import { Injectable } from '@angular/core';
+import Web3 from 'web3';
+import { provider } from 'web3-core';
+import detectEthereumProvider from '@metamask/detect-provider';
+
+@Injectable()
+export class Web3Factory {
+    create(web3Provider: provider): Web3 {
+        return new Web3(web3Provider);
+    }
+
+    /* istanbul ignore next */
+    detectProvider(): Promise<unknown> {
+        return detectEthereumProvider();
+    }
+}

--- a/src/testing/mock-config.ts
+++ b/src/testing/mock-config.ts
@@ -37,11 +37,13 @@ class MockWeb3 extends Web3 {
     }
 }
 
-// noinspection JSUnusedLocalSymbols
 const mockProvider = {
     web3: new MockWeb3(),
     create(provider: HttpProvider): Web3 {
         return this.web3;
+    },
+    detectProvider() {
+        return Promise.resolve('http://localhost:8485');
     },
 };
 

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -13,6 +13,7 @@
         "target": "es2015",
         "typeRoots": ["node_modules/@types"],
         "lib": ["es2017", "dom"],
-        "baseUrl": "src"
+        "baseUrl": "src",
+        "allowSyntheticDefaultImports": true
     }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -1492,6 +1492,11 @@
     merge-source-map "^1.1.0"
     schema-utils "^2.7.0"
 
+"@metamask/detect-provider@^1.2.0":
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/@metamask/detect-provider/-/detect-provider-1.2.0.tgz#3667a7531f2a682e3c3a43eaf3a1958bdb42a696"
+  integrity sha512-ocA76vt+8D0thgXZ7LxFPyqw3H7988qblgzddTDA6B8a/yU0uKV42QR/DhA+Jh11rJjxW0jKvwb5htA6krNZDQ==
+
 "@ngtools/webpack@12.1.4":
   version "12.1.4"
   resolved "https://registry.yarnpkg.com/@ngtools/webpack/-/webpack-12.1.4.tgz#9f7ac5e26b366831b50558bf71dd6e1689743def"


### PR DESCRIPTION
Closes #655 

This integrates MetaMask for enabling users to easily send tokens and ETH to their Raiden account. This feature is accessed in a new dialog where a user can select the token or ETH and specify an amount to send.